### PR TITLE
fix: theme persistence on page reload

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useLayoutEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "./contexts/AuthContext";
 import { BrowserRouter, Routes, Route, Link, useNavigate, useLocation } from "react-router-dom";
@@ -12,8 +12,9 @@ import Settings from "./pages/Settings";
 import AdminPanel from "./pages/AdminPanel";
 import UserDetail from "./pages/UserDetail";
 import UserAvatarMenu from "./components/UserAvatarMenu";
-import { getConfig, getPeople } from "./api/client";
+import { getConfig, getCurrentTheme, getPeople } from "./api/client";
 import { MdDashboard, MdCheckCircle, MdPeople, MdHistory, MdSettings, MdMenu } from "react-icons/md";
+import { applyTheme, DEFAULT_THEME_COLORS } from "./utils/theme";
 import "./App.css";
 
 const PAGES = [
@@ -158,6 +159,38 @@ function AppContent() {
   );
 }
 
+function AuthenticatedApp() {
+  const [themeApplied, setThemeApplied] = useState(false);
+  const { data: currentTheme, isLoading, isError } = useQuery({
+    queryKey: ["current-theme"],
+    queryFn: getCurrentTheme,
+    staleTime: 60_000,
+  });
+
+  useLayoutEffect(() => {
+    if (currentTheme?.colors) {
+      applyTheme(currentTheme.colors);
+      setThemeApplied(true);
+      return;
+    }
+
+    if (isError) {
+      applyTheme(DEFAULT_THEME_COLORS);
+      setThemeApplied(true);
+    }
+  }, [currentTheme, isError]);
+
+  if (isLoading || !themeApplied) {
+    return <div className="app-loading">Loading...</div>;
+  }
+
+  return (
+    <BrowserRouter>
+      <AppContent />
+    </BrowserRouter>
+  );
+}
+
 export default function App() {
   const { isAuthenticated, setupNeeded, loading } = useAuth();
 
@@ -172,9 +205,5 @@ export default function App() {
     return <Login onLoginSuccess={() => window.location.reload()} />;
   }
 
-  return (
-    <BrowserRouter>
-      <AppContent />
-    </BrowserRouter>
-  );
+  return <AuthenticatedApp />;
 }

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -24,6 +24,30 @@ function wrap(ui) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const DARK_THEME = {
+  id: "dark",
+  name: "Dark",
+  colors: {
+    bg: "#080c14",
+    surface: "#16202e",
+    surface2: "#1e2d40",
+    accent: "#73B1DD",
+    success: "#3db87a",
+    warning: "#e8a930",
+    danger: "#e05c6a",
+  },
+};
+
 describe("App", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -38,6 +62,37 @@ describe("App", () => {
     client.getLog.mockResolvedValue([]);
     client.getSetupStatus.mockResolvedValue({ setup_needed: false });
     client.getConfig.mockResolvedValue({ title: "Family Chores" });
+    client.getCurrentTheme.mockResolvedValue(DARK_THEME);
+  });
+
+  it("waits for the saved theme before rendering the authenticated app shell", async () => {
+    const themeRequest = deferred();
+    client.getCurrentTheme.mockReturnValue(themeRequest.promise);
+
+    wrap(<App />);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Board")).not.toBeInTheDocument();
+
+    themeRequest.resolve(DARK_THEME);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Board").length).toBeGreaterThan(0);
+    });
+
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe("#080c14");
+  });
+
+  it("falls back to the default theme when loading the saved theme fails", async () => {
+    client.getCurrentTheme.mockRejectedValue(new Error("theme lookup failed"));
+
+    wrap(<App />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Board").length).toBeGreaterThan(0);
+    });
+
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe("#080c14");
   });
 
   it("renders the app title", async () => {

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -1,3 +1,13 @@
+export const DEFAULT_THEME_COLORS = {
+  bg: "#080c14",
+  surface: "#16202e",
+  surface2: "#1e2d40",
+  accent: "#73B1DD",
+  success: "#3db87a",
+  warning: "#e8a930",
+  danger: "#e05c6a",
+};
+
 function getBrightness(hex) {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);


### PR DESCRIPTION
Closes #10

## Summary
- bootstrap the saved theme during authenticated app startup instead of only in Settings
- block the authenticated app shell until the current theme has been fetched and applied to avoid a default-theme flash
- add app-level regression tests for startup theme loading and fallback behavior

## Testing
- npm test -- --run src/__tests__/App.test.jsx
- npm test -- --run src/__tests__/ThemeSettings.test.jsx