### PR TITLE
feat: route user detail and filter activity history

### DIFF
--- a/backend/app/routers/log.py
+++ b/backend/app/routers/log.py
@@ -24,6 +24,7 @@ async def get_log(
     person: Optional[str] = Query(None),
     chore_id: Optional[str] = Query(None),
     action: Optional[str] = Query(None),
+    actions: Optional[list[str]] = Query(None),
     start_date: Optional[date] = Query(None),
     end_date: Optional[date] = Query(None),
     current_user: str = Depends(get_current_user),
@@ -37,6 +38,8 @@ async def get_log(
         query = query.where(ChoreLog.chore_id == int(chore_id))
     if action:
         query = query.where(ChoreLog.action == action)
+    if actions:
+        query = query.where(ChoreLog.action.in_(actions))
     if start_date:
         query = query.where(ChoreLog.timestamp >= datetime.combine(start_date, datetime.min.time()))
     if end_date:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -366,6 +366,7 @@ class TestLogAPI:
     @pytest.mark.asyncio
     async def test_log_filters_multiple_actions(self, authenticated_client):
         await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
         r = await authenticated_client.post("/chores", json=ROTATING_CHORE)
         chore_id = r.json()["id"]
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -360,3 +360,29 @@ class TestPointsAPI:
         r = await authenticated_client.get("/health")
         assert r.status_code == 200
         assert r.json() == {"status": "ok"}
+
+
+class TestLogAPI:
+    @pytest.mark.asyncio
+    async def test_log_filters_multiple_actions(self, authenticated_client):
+        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        r = await authenticated_client.post("/chores", json=ROTATING_CHORE)
+        chore_id = r.json()["id"]
+
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        await authenticated_client.post(f"/chores/{chore_id}/reassign", json={"assignee": "Bob"})
+        await authenticated_client.put(f"/chores/{chore_id}", json={"points": 9})
+
+        r = await authenticated_client.get("/log?person=Alice&actions=completed&actions=reassigned")
+        assert r.status_code == 200
+        actions = [entry["action"] for entry in r.json()]
+        assert "completed" in actions
+        assert "reassigned" not in actions
+
+        r = await authenticated_client.get("/log?actions=completed&actions=reassigned")
+        assert r.status_code == 200
+        actions = [entry["action"] for entry in r.json()]
+        assert "completed" in actions
+        assert "reassigned" in actions
+        assert "updated" not in actions

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,7 +29,6 @@ function AppContent() {
     const saved = localStorage.getItem("sidebarOpen");
     return saved === null ? true : saved === "true";
   });
-  const [selectedUser, setSelectedUser] = useState(null);
   const [appTitle, setAppTitle] = useState("Family Chores");
   const [navVisible, setNavVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
@@ -137,22 +136,15 @@ function AppContent() {
       <div className={`sidebar-backdrop ${sidebarOpen ? "open" : ""}`} onClick={() => setSidebarOpen(false)}></div>
       <div className="app-content">
         <main className="app-main">
-          {selectedUser && (
-            <UserDetail
-              userName={selectedUser}
-              onBack={() => setSelectedUser(null)}
-            />
-          )}
-          {!selectedUser && (
-            <Routes>
-              <Route path="/" element={<Dashboard onSelectUser={setSelectedUser} />} />
-              <Route path="/chores" element={<Manage />} />
-              <Route path="/users" element={<UserManagement />} />
-              <Route path="/log" element={<Log />} />
-              <Route path="/settings" element={<Settings onTitleUpdate={(newTitle) => setAppTitle(newTitle)} />} />
-              <Route path="/admin" element={<AdminPanel />} />
-            </Routes>
-          )}
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/chores" element={<Manage />} />
+            <Route path="/users" element={<UserManagement />} />
+            <Route path="/users/:userName" element={<UserDetail />} />
+            <Route path="/log" element={<Log />} />
+            <Route path="/settings" element={<Settings onTitleUpdate={(newTitle) => setAppTitle(newTitle)} />} />
+            <Route path="/admin" element={<AdminPanel />} />
+          </Routes>
         </main>
       </div>
     </div>

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -52,6 +52,7 @@ describe("App", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     localStorage.clear();
+    window.history.pushState({}, "", "/");
     // Mock API calls
     client.getChores.mockResolvedValue([]);
     client.getPeople.mockResolvedValue([
@@ -147,6 +148,33 @@ describe("App", () => {
     fireEvent.click(usersLink);
     await waitFor(() => {
       expect(screen.getByText("Manage Users")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the user detail route directly", async () => {
+    window.history.pushState({}, "", "/users/Alice");
+    client.getUserStats.mockResolvedValue({
+      name: "Alice",
+      total_points: 10,
+      points_7d: 4,
+      points_30d: 10,
+      completed_count: 2,
+      skipped_count: 1,
+    });
+    client.getLog.mockResolvedValue([
+      {
+        id: 1,
+        chore_id: 1,
+        chore_name: "Vacuum",
+        action: "completed",
+        timestamp: "2026-04-20T10:00:00Z",
+      },
+    ]);
+
+    wrap(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice", { selector: "h1" })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import Dashboard from "../pages/Dashboard";
 import * as client from "../api/client";
 
@@ -45,7 +46,16 @@ const SUMMARY = [
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/"]}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
 }
 
 describe("Dashboard", () => {
@@ -90,14 +100,28 @@ describe("Dashboard", () => {
     );
   });
 
-  it("calls onSelectUser when clicking a user card", async () => {
-    const onSelectUser = vi.fn();
-    wrap(<Dashboard onSelectUser={onSelectUser} />);
+  it("navigates to the user detail route when clicking a user card", async () => {
+    wrap(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <Dashboard />
+              <LocationDisplay />
+            </>
+          }
+        />
+        <Route path="/users/:userName" element={<LocationDisplay />} />
+      </Routes>
+    );
     await waitFor(() => expect(screen.getByText("Alice", { selector: ".uc-name" })).toBeInTheDocument());
 
     const aliceCard = screen.getByText("Alice", { selector: ".uc-name" }).closest(".user-card");
     fireEvent.click(aliceCard);
 
-    expect(onSelectUser).toHaveBeenCalledWith("Alice");
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/users/Alice");
+    });
   });
 });

--- a/frontend/src/__tests__/UserDetail.test.jsx
+++ b/frontend/src/__tests__/UserDetail.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import UserDetail from "../pages/UserDetail";
 import * as client from "../api/client";
 
@@ -38,7 +39,16 @@ const USER_STATS = {
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/", `/users/${USER_NAME}`]} initialIndex={1}>
+        <Routes>
+          <Route path="/" element={<div>Board</div>} />
+          <Route path="/users/:userName" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 describe("UserDetail", () => {
@@ -49,31 +59,31 @@ describe("UserDetail", () => {
   });
 
   it("renders user name", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getByText("Alice")).toBeInTheDocument();
     });
   });
 
   it("shows back button", async () => {
-    const onBack = vi.fn();
-    wrap(<UserDetail userName={USER_NAME} onBack={onBack} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /back|←/i })).toBeInTheDocument();
     });
   });
 
-  it("calls onBack when back button clicked", async () => {
-    const onBack = vi.fn();
-    wrap(<UserDetail userName={USER_NAME} onBack={onBack} />);
+  it("navigates back when back button clicked", async () => {
+    wrap(<UserDetail />);
     await waitFor(() => {
       fireEvent.click(screen.getByRole("button", { name: /back|←/i }));
     });
-    expect(onBack).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText("Board")).toBeInTheDocument();
+    });
   });
 
   it("displays user statistics", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getByText(/Total Points/i)).toBeInTheDocument();
       expect(screen.getByText(/Last 7 Days/i)).toBeInTheDocument();
@@ -82,7 +92,7 @@ describe("UserDetail", () => {
   });
 
   it("shows 7-day and 30-day points", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getByText(/7.*day|7d/i)).toBeInTheDocument();
       expect(screen.getByText(/30.*day|30d/i)).toBeInTheDocument();
@@ -90,7 +100,7 @@ describe("UserDetail", () => {
   });
 
   it("shows completion and skip counts", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getAllByText(/Completed/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Skipped/i).length).toBeGreaterThan(0);
@@ -98,23 +108,26 @@ describe("UserDetail", () => {
   });
 
   it("displays user history log entries", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     await waitFor(() => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
       expect(screen.getByText("Take out trash")).toBeInTheDocument();
     });
   });
 
-  it("fetches log filtered by user", async () => {
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+  it("fetches chore activity history filtered by user", async () => {
+    wrap(<UserDetail />);
     await waitFor(() => {
-      expect(client.getLog).toHaveBeenCalledWith({ person: USER_NAME });
+      expect(client.getLog).toHaveBeenCalledWith({
+        person: USER_NAME,
+        actions: ["completed", "skipped", "reassigned"],
+      });
     });
   });
 
   it("shows loading state", () => {
     client.getLog.mockImplementation(() => new Promise(() => {}));
-    wrap(<UserDetail userName={USER_NAME} onBack={vi.fn()} />);
+    wrap(<UserDetail />);
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -68,6 +68,9 @@ export const getLog = (filters = {}) => {
   if (filters.person) params.append("person", filters.person);
   if (filters.chore_id) params.append("chore_id", filters.chore_id);
   if (filters.action) params.append("action", filters.action);
+  if (filters.actions) {
+    filters.actions.forEach((action) => params.append("actions", action));
+  }
   if (filters.start_date) params.append("start_date", filters.start_date);
   if (filters.end_date) params.append("end_date", filters.end_date);
   const queryString = params.toString();

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getChores, getPeople, getPointsSummary, completeChore, skipChore, reassignChore } from "../api/client";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { getChores, getPeople, getPointsSummary } from "../api/client";
 import UserCard from "../components/UserCard";
 import ChoreRowActions from "../components/ChoreRowActions";
 import "./Dashboard.css";
 
-export default function Dashboard({ onSelectUser }) {
+export default function Dashboard() {
+  const navigate = useNavigate();
   const { data: chores = [], isLoading } = useQuery({
     queryKey: ["chores"],
     queryFn: getChores,
@@ -48,7 +50,7 @@ export default function Dashboard({ onSelectUser }) {
         {people.map((person) => (
           <div
             key={person.name}
-            onClick={() => onSelectUser?.(person.name)}
+            onClick={() => navigate(`/users/${encodeURIComponent(person.name)}`)}
             style={{ cursor: "pointer" }}
           >
             <UserCard

--- a/frontend/src/pages/UserDetail.jsx
+++ b/frontend/src/pages/UserDetail.jsx
@@ -1,24 +1,32 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router-dom";
 import { getLog, getUserStats } from "../api/client";
 import "./UserDetail.css";
 
-export default function UserDetail({ userName, onBack }) {
+const USER_ACTIVITY_ACTIONS = ["completed", "skipped", "reassigned"];
+
+export default function UserDetail() {
+  const { userName = "" } = useParams();
+  const navigate = useNavigate();
+
   const { data: stats, isLoading: statsLoading } = useQuery({
     queryKey: ["user-stats", userName],
     queryFn: () => getUserStats(userName),
+    enabled: Boolean(userName),
   });
 
   const { data: history = [], isLoading: historyLoading } = useQuery({
-    queryKey: ["log", { person: userName }],
-    queryFn: () => getLog({ person: userName }),
+    queryKey: ["log", { person: userName, actions: USER_ACTIVITY_ACTIONS }],
+    queryFn: () => getLog({ person: userName, actions: USER_ACTIVITY_ACTIONS }),
+    enabled: Boolean(userName),
   });
 
   if (statsLoading || historyLoading) return <div className="loading">Loading…</div>;
 
   return (
     <div className="user-detail">
-      <button className="back-btn" onClick={onBack} aria-label="Back">
+      <button className="back-btn" onClick={() => navigate(-1)} aria-label="Back">
         ← Back
       </button>
 


### PR DESCRIPTION
Closes #15

## Summary
- convert user detail into a real `/users/:userName` route instead of app-local selection state
- navigate to user detail from dashboard cards using the router so refresh and navigation work correctly
- scope user detail history to chore activity only by requesting `completed`, `skipped`, and `reassigned` log actions
- extend the log API/client to support multi-action filtering

## Testing
- npm test -- --run src/__tests__/Dashboard.test.jsx
- npm test -- --run src/__tests__/UserDetail.test.jsx
- npm test -- --run src/__tests__/App.test.jsx
- python3 -m py_compile backend/app/routers/log.py backend/tests/test_api.py

## Notes
- targeted backend pytest for the new log filter still appeared to hang in this environment before returning a result