### PR TITLE
feat: add history links to chore and user cards

### DIFF
--- a/frontend/src/__tests__/ChoreList.test.jsx
+++ b/frontend/src/__tests__/ChoreList.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import ChoreList from "../components/ChoreList";
 import * as client from "../api/client";
 
@@ -41,7 +42,16 @@ const PEOPLE = [
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/"]}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 describe("ChoreList", () => {
@@ -112,5 +122,30 @@ describe("ChoreList", () => {
     const choreCard = screen.getByText("Vacuum").closest("article");
     expect(choreCard).toHaveClass("chore-card");
     expect(choreCard.querySelectorAll("button").length).toBeGreaterThan(0);
+  });
+
+  it("navigates to filtered log history for a chore", async () => {
+    wrap(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <ChoreList />
+              <LocationDisplay />
+            </>
+          }
+        />
+        <Route path="/log" element={<LocationDisplay />} />
+      </Routes>
+    );
+    await waitFor(() => screen.getByText("Vacuum"));
+
+    fireEvent.click(screen.getByText("Vacuum"));
+    fireEvent.click(screen.getByRole("button", { name: /history for vacuum/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/log?chore_id=vacuum");
+    });
   });
 });

--- a/frontend/src/__tests__/Manage.test.jsx
+++ b/frontend/src/__tests__/Manage.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 import Manage from "../pages/Manage";
 import * as client from "../api/client";
 
@@ -48,7 +49,11 @@ const PEOPLE = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }];
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/chores"]}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 describe("Manage page", () => {

--- a/frontend/src/__tests__/UserManagement.test.jsx
+++ b/frontend/src/__tests__/UserManagement.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { AuthProvider } from "../contexts/AuthContext";
 import UserManagement from "../components/UserManagement";
 import * as client from "../api/client";
@@ -15,14 +16,21 @@ vi.mock("../contexts/AuthContext", () => ({
 
 const PEOPLE = [
   { id: 1, name: "Alice", color: "#3B6EA0", goal_7d: 20, goal_30d: 80, is_admin: true },
-  { id: 2, name: "Bob", color: "#8B5E8A", goal_7d: 15, goal_30d: 60, is_admin: false },
+  { id: 2, name: "Bob Smith", color: "#8B5E8A", goal_7d: 15, goal_30d: 60, is_admin: false },
 ];
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/"]}>{ui}</MemoryRouter>
+    </QueryClientProvider>
   );
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 describe("UserManagement", () => {
@@ -35,7 +43,7 @@ describe("UserManagement", () => {
     wrap(<UserManagement />);
     await waitFor(() => {
       expect(screen.getByText("Alice")).toBeInTheDocument();
-      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Bob Smith")).toBeInTheDocument();
     });
   });
 
@@ -80,6 +88,31 @@ describe("UserManagement", () => {
 
     await waitFor(() => {
       expect(client.deletePerson).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("navigates to filtered log history for a user", async () => {
+    wrap(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <UserManagement />
+              <LocationDisplay />
+            </>
+          }
+        />
+        <Route path="/log" element={<LocationDisplay />} />
+      </Routes>
+    );
+
+    await waitFor(() => screen.getByText("Bob Smith"));
+    const historyButtons = screen.getAllByRole("button", { name: "History" });
+    fireEvent.click(historyButtons[1]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/log?person=Bob%20Smith");
     });
   });
 

--- a/frontend/src/components/ChoreList.jsx
+++ b/frontend/src/components/ChoreList.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import { getChores, getPeople } from "../api/client";
 import { MdSchedule, MdPerson, MdStar, MdEdit, MdDelete, MdAccessTime } from "react-icons/md";
 import "./ChoreList.css";
@@ -13,6 +14,7 @@ const ICONS = {
 };
 
 export default function ChoreList({ onEdit, onDelete, chores: externalChores, people: externalPeople }) {
+  const navigate = useNavigate();
   const [expandedChoreId, setExpandedChoreId] = useState(null);
   const { data: queriedChores = [], isLoading: choresLoading } = useQuery({
     queryKey: ["chores"],
@@ -103,6 +105,16 @@ export default function ChoreList({ onEdit, onDelete, chores: externalChores, pe
               aria-label={`Edit ${chore.name}`}
             >
               Edit
+            </button>
+            <button
+              className="chore-action-link"
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/log?chore_id=${encodeURIComponent(chore.id)}`);
+              }}
+              aria-label={`History for ${chore.name}`}
+            >
+              History
             </button>
             <button
               className="chore-action-link chore-action-delete"

--- a/frontend/src/components/UserManagement.jsx
+++ b/frontend/src/components/UserManagement.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { MdAdd } from "react-icons/md";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { getPeople, createPerson, updatePerson, deletePerson } from "../api/client";
 import "./UserManagement.css";
 
 export default function UserManagement() {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { user: authUser } = useAuth();
   const { data: people = [], isLoading } = useQuery({
@@ -175,6 +177,12 @@ export default function UserManagement() {
                   onClick={() => handleOpenEditDialog(person)}
                 >
                   Edit
+                </button>
+                <button
+                  className="user-action-link"
+                  onClick={() => navigate(`/log?person=${encodeURIComponent(person.name)}`)}
+                >
+                  History
                 </button>
                 <button
                   className="user-action-link user-action-delete"


### PR DESCRIPTION
Closes #4

## Summary
- add a History action to chore cards that navigates to `/log` filtered by `chore_id`
- add a History action to user cards that navigates to `/log` filtered by `person`
- reuse the existing log query-param filtering already implemented for issue #3
- add focused test coverage for both navigation paths

## Testing
- npm test -- --run src/__tests__/ChoreList.test.jsx
- npm test -- --run src/__tests__/UserManagement.test.jsx

## Notes
- the issue body says `/logs`, but the current app route is `/log`, so the links target the existing route