### PR TITLE
feat: sync chore filters with URL params

### DIFF
--- a/frontend/src/__tests__/Manage.test.jsx
+++ b/frontend/src/__tests__/Manage.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import Manage from "../pages/Manage";
 import * as client from "../api/client";
 
@@ -47,11 +47,19 @@ const CHORES = [
 
 const PEOPLE = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }];
 
-function wrap(ui) {
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}{location.search}</div>;
+}
+
+function wrap(ui, { initialEntries = ["/chores"] } = {}) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={["/chores"]}>{ui}</MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
+        {ui}
+        <LocationDisplay />
+      </MemoryRouter>
     </QueryClientProvider>
   );
 }
@@ -157,5 +165,40 @@ describe("Manage page", () => {
     await waitFor(() =>
       expect(screen.getByText(/No chores yet/i)).toBeInTheDocument()
     );
+  });
+
+  it("hydrates filters from URL params on initial render", async () => {
+    wrap(<Manage />, { initialEntries: ["/chores?state=complete"] });
+
+    await waitFor(() => expect(screen.getByText("Dishes")).toBeInTheDocument());
+    expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 chores")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    expect(screen.getByLabelText("State")).toHaveValue("complete");
+    expect(screen.getByTestId("location")).toHaveTextContent("/chores?state=complete");
+  });
+
+  it("updates URL params when filters change", async () => {
+    wrap(<Manage />);
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    fireEvent.change(screen.getByLabelText("State"), { target: { value: "complete" } });
+
+    await waitFor(() => expect(screen.getByText("Dishes")).toBeInTheDocument());
+    expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("/chores?state=complete");
+  });
+
+  it("clears URL params when filters are reset", async () => {
+    wrap(<Manage />, { initialEntries: ["/chores?assignment_type=open&disabled=false"] });
+
+    await waitFor(() => expect(screen.getByText("Dishes")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+    expect(screen.getByText("Dishes")).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("/chores");
   });
 });

--- a/frontend/src/pages/Manage.jsx
+++ b/frontend/src/pages/Manage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
 import { MdFilterList, MdAdd } from "react-icons/md";
 import { getChores, getPeople, createChore, updateChore, deleteChore } from "../api/client";
 import ChoreForm from "../components/ChoreForm";
@@ -7,12 +8,30 @@ import ChoreList from "../components/ChoreList";
 import Modal from "../components/Modal";
 import "./Manage.css";
 
+function getFiltersFromSearchParams(searchParams) {
+  const filters = {};
+  const scheduleType = searchParams.get("schedule_type");
+  const assignmentType = searchParams.get("assignment_type");
+  const state = searchParams.get("state");
+  const disabled = searchParams.get("disabled");
+
+  if (scheduleType) filters.schedule_type = scheduleType;
+  if (assignmentType) filters.assignment_type = assignmentType;
+  if (state) filters.state = state;
+  if (disabled === "true") filters.disabled = true;
+  if (disabled === "false") filters.disabled = false;
+
+  return filters;
+}
+
 export default function Manage() {
   const qc = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [modal, setModal] = useState(null); // null | { mode: "create" } | { mode: "edit", chore }
   const [deleteTarget, setDeleteTarget] = useState(null); // chore to confirm-delete
-  const [filters, setFilters] = useState({});
   const [filtersExpanded, setFiltersExpanded] = useState(false);
+
+  const filters = useMemo(() => getFiltersFromSearchParams(searchParams), [searchParams]);
 
   const { data: chores = [], isLoading } = useQuery({
     queryKey: ["chores"],
@@ -42,14 +61,21 @@ export default function Manage() {
   });
 
   const handleFilterChange = useCallback((key, value) => {
-    setFilters((prev) => ({
-      ...prev,
-      [key]: value || undefined,
-    }));
-  }, []);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+
+      if (value === undefined || value === "") {
+        next.delete(key);
+      } else {
+        next.set(key, value);
+      }
+
+      return next;
+    });
+  }, [setSearchParams]);
 
   const handleClearFilters = () => {
-    setFilters({});
+    setSearchParams({});
   };
 
   const filtered = useMemo(() => {
@@ -150,18 +176,14 @@ export default function Manage() {
                 <label htmlFor="filter-disabled">Status</label>
                 <select
                   id="filter-disabled"
-                  value={filters.disabled === undefined ? "" : filters.disabled ? "disabled" : "enabled"}
+                  value={filters.disabled === undefined ? "" : String(filters.disabled)}
                   onChange={(e) => {
-                    if (e.target.value === "") {
-                      handleFilterChange("disabled", undefined);
-                    } else {
-                      handleFilterChange("disabled", e.target.value === "disabled");
-                    }
+                    handleFilterChange("disabled", e.target.value || undefined);
                   }}
                 >
                   <option value="">All chores</option>
-                  <option value="enabled">Enabled only</option>
-                  <option value="disabled">Disabled only</option>
+                  <option value="false">Enabled only</option>
+                  <option value="true">Disabled only</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- move chore page filters to useSearchParams so /chores filters persist in the URL
- hydrate schedule_type, assignment_type, state, and disabled from query params on load
- add regression coverage for URL-driven filters, updates, and clearing

Closes #13

## Testing
- npm test -- --run src/__tests__/Manage.test.jsx
- npm test -- --run src/__tests__/ChoreList.test.jsx