### PR TITLE
feat: sort chores by next due date

### DIFF
--- a/frontend/src/__tests__/ChoreList.test.jsx
+++ b/frontend/src/__tests__/ChoreList.test.jsx
@@ -22,6 +22,18 @@ const CHORES = [
     next_due: "2026-05-01",
   },
   {
+    id: "bathroom",
+    unique_id: "bathroom",
+    name: "Bathroom",
+    points: 2,
+    state: "due",
+    disabled: false,
+    current_assignee: null,
+    schedule_summary: "Weekly on Tue",
+    assignment_type: "open",
+    next_due: "2026-05-01",
+  },
+  {
     id: "dishes",
     unique_id: "dishes",
     name: "Dishes",
@@ -32,6 +44,18 @@ const CHORES = [
     schedule_summary: "Every day",
     assignment_type: "rotating",
     next_due: "2026-05-02",
+  },
+  {
+    id: "laundry",
+    unique_id: "laundry",
+    name: "Laundry",
+    points: 1,
+    state: "due",
+    disabled: false,
+    current_assignee: "Alice",
+    schedule_summary: "Every week",
+    assignment_type: "fixed",
+    next_due: null,
   },
 ];
 
@@ -74,7 +98,7 @@ describe("ChoreList", () => {
     await waitFor(() => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
       expect(screen.getByText("5")).toBeInTheDocument();
-      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
     });
   });
 
@@ -91,7 +115,7 @@ describe("ChoreList", () => {
     wrap(<ChoreList />);
     await waitFor(() => {
       // current_assignee names appear in the assignment info
-      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
     });
   });
 
@@ -147,5 +171,17 @@ describe("ChoreList", () => {
     await waitFor(() => {
       expect(screen.getByTestId("location")).toHaveTextContent("/log?chore_id=vacuum");
     });
+  });
+
+  it("sorts chores by next due date with tied dates by name and no-date chores last", async () => {
+    wrap(<ChoreList />);
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+
+    const choreNames = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+
+    expect(choreNames).toEqual(["Bathroom", "Vacuum", "Dishes", "Laundry"]);
   });
 });

--- a/frontend/src/__tests__/Manage.test.jsx
+++ b/frontend/src/__tests__/Manage.test.jsx
@@ -27,6 +27,23 @@ const CHORES = [
     age: 1,
   },
   {
+    id: "bathroom",
+    unique_id: "bathroom",
+    name: "Bathroom",
+    state: "due",
+    disabled: false,
+    assignment_type: "open",
+    current_assignee: null,
+    schedule_type: "weekly",
+    schedule_config: { days: [2] },
+    schedule_summary: "Weekly on Wed",
+    eligible_people: [],
+    assignee: null,
+    points: 1,
+    next_due: "2024-01-15",
+    age: 0,
+  },
+  {
     id: "dishes",
     unique_id: "dishes",
     name: "Dishes",
@@ -42,6 +59,23 @@ const CHORES = [
     points: 0,
     next_due: "2024-01-20",
     age: -5,
+  },
+  {
+    id: "laundry",
+    unique_id: "laundry",
+    name: "Laundry",
+    state: "due",
+    disabled: false,
+    assignment_type: "fixed",
+    current_assignee: "Bob",
+    schedule_type: "interval",
+    schedule_config: { days: 7 },
+    schedule_summary: "Every 7 days",
+    eligible_people: [],
+    assignee: "Bob",
+    points: 2,
+    next_due: null,
+    age: null,
   },
 ];
 
@@ -78,6 +112,8 @@ describe("Manage page", () => {
     wrap(<Manage />);
     await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
     expect(screen.getByText("Dishes")).toBeInTheDocument();
+    expect(screen.getByText("Bathroom")).toBeInTheDocument();
+    expect(screen.getByText("Laundry")).toBeInTheDocument();
   });
 
   it("shows schedule summaries", async () => {
@@ -172,7 +208,7 @@ describe("Manage page", () => {
 
     await waitFor(() => expect(screen.getByText("Dishes")).toBeInTheDocument());
     expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 2 chores")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 4 chores")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
     expect(screen.getByLabelText("State")).toHaveValue("complete");
@@ -200,5 +236,29 @@ describe("Manage page", () => {
     await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
     expect(screen.getByText("Dishes")).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent("/chores");
+  });
+
+  it("sorts chores by next due date with name tiebreakers and no-date chores last", async () => {
+    wrap(<Manage />);
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+
+    const choreNames = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+
+    expect(choreNames).toEqual(["Bathroom", "Vacuum", "Dishes", "Laundry"]);
+  });
+
+  it("preserves due-date ordering after filters are applied", async () => {
+    wrap(<Manage />, { initialEntries: ["/chores?assignment_type=open"] });
+
+    await waitFor(() => expect(screen.getByText("Bathroom")).toBeInTheDocument());
+
+    const choreNames = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent);
+
+    expect(choreNames).toEqual(["Bathroom", "Dishes"]);
   });
 });

--- a/frontend/src/components/ChoreList.jsx
+++ b/frontend/src/components/ChoreList.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { getChores, getPeople } from "../api/client";
 import { MdSchedule, MdPerson, MdStar, MdEdit, MdDelete, MdAccessTime } from "react-icons/md";
+import { compareChoresByNextDue } from "../utils/choreSort";
 import "./ChoreList.css";
 
 const STATE_LABELS = { due: "Due", complete: "Done" };
@@ -33,7 +34,7 @@ export default function ChoreList({ onEdit, onDelete, chores: externalChores, pe
 
   if (choresLoading && !externalChores) return <div className="loading">Loading chores…</div>;
 
-  const sorted = [...chores].sort((a, b) => a.name.localeCompare(b.name));
+  const sorted = [...chores].sort(compareChoresByNextDue);
 
   if (sorted.length === 0) {
     return <div className="empty">No chores yet. Add one to get started.</div>;

--- a/frontend/src/pages/Manage.jsx
+++ b/frontend/src/pages/Manage.jsx
@@ -6,6 +6,7 @@ import { getChores, getPeople, createChore, updateChore, deleteChore } from "../
 import ChoreForm from "../components/ChoreForm";
 import ChoreList from "../components/ChoreList";
 import Modal from "../components/Modal";
+import { compareChoresByNextDue } from "../utils/choreSort";
 import "./Manage.css";
 
 function getFiltersFromSearchParams(searchParams) {
@@ -88,7 +89,7 @@ export default function Manage() {
     });
   }, [chores, filters]);
 
-  const sorted = [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+  const sorted = [...filtered].sort(compareChoresByNextDue);
 
   const scheduleTypes = [...new Set(chores.map(c => c.schedule_type))].sort();
   const assignmentTypes = [...new Set(chores.map(c => c.assignment_type))].sort();

--- a/frontend/src/utils/choreSort.js
+++ b/frontend/src/utils/choreSort.js
@@ -1,0 +1,13 @@
+function getNextDueTimestamp(nextDue) {
+  if (!nextDue) return Number.POSITIVE_INFINITY;
+
+  const timestamp = Date.parse(`${nextDue}T00:00:00`);
+  return Number.isNaN(timestamp) ? Number.POSITIVE_INFINITY : timestamp;
+}
+
+export function compareChoresByNextDue(a, b) {
+  const dueDiff = getNextDueTimestamp(a.next_due) - getNextDueTimestamp(b.next_due);
+  if (dueDiff !== 0) return dueDiff;
+
+  return a.name.localeCompare(b.name);
+}


### PR DESCRIPTION
## Summary
- sort chores by next_due ascending with name as the stable tiebreaker
- keep chores with no next_due at the end of the chores list
- add regression coverage for tie handling, no-date chores, and filtered ordering

Closes #19

## Testing
- npm test -- --run src/__tests__/Manage.test.jsx
- npm test -- --run src/__tests__/ChoreList.test.jsx