### PR TITLE
feat: add chore assignee filtering

### DIFF
--- a/frontend/src/__tests__/ChoreList.test.jsx
+++ b/frontend/src/__tests__/ChoreList.test.jsx
@@ -55,6 +55,7 @@ const CHORES = [
     current_assignee: "Alice",
     schedule_summary: "Every week",
     assignment_type: "fixed",
+    assignee: "Alice",
     next_due: null,
   },
 ];
@@ -99,6 +100,7 @@ describe("ChoreList", () => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
       expect(screen.getByText("5")).toBeInTheDocument();
       expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
+      expect(screen.getByText("Unassigned")).toBeInTheDocument();
     });
   });
 
@@ -114,8 +116,10 @@ describe("ChoreList", () => {
   it("shows assignment info for chores", async () => {
     wrap(<ChoreList />);
     await waitFor(() => {
-      // current_assignee names appear in the assignment info
+      // Assignment labels cover fixed, rotating, and open chores
       expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Unassigned")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/__tests__/Manage.test.jsx
+++ b/frontend/src/__tests__/Manage.test.jsx
@@ -44,6 +44,23 @@ const CHORES = [
     age: 0,
   },
   {
+    id: "countertops",
+    unique_id: "countertops",
+    name: "Countertops",
+    state: "due",
+    disabled: false,
+    assignment_type: "fixed",
+    current_assignee: "Bob",
+    schedule_type: "weekly",
+    schedule_config: { days: [3] },
+    schedule_summary: "Weekly on Thu",
+    eligible_people: [],
+    assignee: "Bob",
+    points: 2,
+    next_due: "2024-01-16",
+    age: 0,
+  },
+  {
     id: "dishes",
     unique_id: "dishes",
     name: "Dishes",
@@ -113,6 +130,7 @@ describe("Manage page", () => {
     await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
     expect(screen.getByText("Dishes")).toBeInTheDocument();
     expect(screen.getByText("Bathroom")).toBeInTheDocument();
+    expect(screen.getByText("Countertops")).toBeInTheDocument();
     expect(screen.getByText("Laundry")).toBeInTheDocument();
   });
 
@@ -127,6 +145,8 @@ describe("Manage page", () => {
     await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
     // ChoreList renders assignment_type info for each chore
     expect(screen.getByText("rotating")).toBeInTheDocument();
+    expect(screen.getAllByText("Bob").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Unassigned").length).toBeGreaterThan(0);
   });
 
   it("shows Add Chore button", async () => {
@@ -208,7 +228,7 @@ describe("Manage page", () => {
 
     await waitFor(() => expect(screen.getByText("Dishes")).toBeInTheDocument());
     expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 4 chores")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 5 chores")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
     expect(screen.getByLabelText("State")).toHaveValue("complete");
@@ -238,6 +258,47 @@ describe("Manage page", () => {
     expect(screen.getByTestId("location")).toHaveTextContent("/chores");
   });
 
+  it("hydrates assignee filter from URL params on initial render", async () => {
+    wrap(<Manage />, { initialEntries: ["/chores?assignee=Bob"] });
+
+    await waitFor(() => expect(screen.getByText("Countertops")).toBeInTheDocument());
+    expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bathroom")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dishes")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    expect(screen.getByLabelText("Assignee")).toHaveValue("Bob");
+    expect(screen.getByTestId("location")).toHaveTextContent("/chores?assignee=Bob");
+  });
+
+  it("updates URL params when assignee filter changes", async () => {
+    wrap(<Manage />);
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    fireEvent.change(screen.getByLabelText("Assignee"), { target: { value: "Alice" } });
+
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+    expect(screen.queryByText("Bathroom")).not.toBeInTheDocument();
+    expect(screen.queryByText("Countertops")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dishes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Laundry")).not.toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("/chores?assignee=Alice");
+  });
+
+  it("filters chores by unassigned assignee", async () => {
+    wrap(<Manage />, { initialEntries: ["/chores?assignee=unassigned"] });
+
+    await waitFor(() => expect(screen.getByText("Bathroom")).toBeInTheDocument());
+    expect(screen.getByText("Dishes")).toBeInTheDocument();
+    expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
+    expect(screen.queryByText("Countertops")).not.toBeInTheDocument();
+    expect(screen.queryByText("Laundry")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    expect(screen.getByLabelText("Assignee")).toHaveValue("unassigned");
+  });
+
   it("sorts chores by next due date with name tiebreakers and no-date chores last", async () => {
     wrap(<Manage />);
 
@@ -247,7 +308,7 @@ describe("Manage page", () => {
       .getAllByRole("heading", { level: 3 })
       .map((heading) => heading.textContent);
 
-    expect(choreNames).toEqual(["Bathroom", "Vacuum", "Dishes", "Laundry"]);
+    expect(choreNames).toEqual(["Bathroom", "Vacuum", "Countertops", "Dishes", "Laundry"]);
   });
 
   it("preserves due-date ordering after filters are applied", async () => {

--- a/frontend/src/components/ChoreList.css
+++ b/frontend/src/components/ChoreList.css
@@ -202,29 +202,70 @@
   word-break: break-word;
 }
 
-.assignment-info {
+.points-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(115, 177, 221, 0.12);
+  color: var(--text);
+}
+
+.points-value {
+  font-weight: 600;
+  line-height: 1;
+}
+
+.points-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.assignment-row {
   display: flex;
   gap: 0.5rem;
   align-items: center;
   flex-wrap: wrap;
 }
 
+.assignment-info {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  width: fit-content;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+}
+
+.assignment-icon {
+  font-size: 0.95rem;
+  flex-shrink: 0;
+}
+
 .assignment-type {
-  padding: 0.2rem 0.5rem;
-  border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: capitalize;
 }
 
-.assignment-type.rotating {
+.assignment-info.rotating {
   background: rgba(115, 177, 221, 0.15);
   color: var(--accent);
 }
 
-.assignment-type.open {
+.assignment-info.open {
   background: rgba(232, 169, 48, 0.15);
   color: var(--warning);
+}
+
+.assignment-info.fixed {
+  background: rgba(61, 184, 122, 0.15);
+  color: var(--success);
 }
 
 .assignee-name {

--- a/frontend/src/components/ChoreList.jsx
+++ b/frontend/src/components/ChoreList.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { getChores, getPeople } from "../api/client";
-import { MdSchedule, MdPerson, MdStar, MdEdit, MdDelete, MdAccessTime } from "react-icons/md";
+import { MdSchedule, MdPerson, MdEdit, MdDelete, MdAccessTime } from "react-icons/md";
 import { getChoreAssigneeLabel } from "../utils/choreAssignee";
 import { compareChoresByNextDue } from "../utils/choreSort";
 import "./ChoreList.css";
@@ -12,7 +12,6 @@ const STATE_LABELS = { due: "Due", complete: "Done" };
 const ICONS = {
   schedule: MdSchedule,
   assignee: MdPerson,
-  points: MdStar,
 };
 
 export default function ChoreList({ onEdit, onDelete, chores: externalChores, people: externalPeople }) {
@@ -57,25 +56,28 @@ export default function ChoreList({ onEdit, onDelete, chores: externalChores, pe
                 <div className="chore-details">
                   <div className="chore-detail-item icon-only">
                     <div className="detail-content">
-                      <span className="detail-value">{chore.points ?? 0}</span>
+                      <div className="points-info">
+                        <span className="points-value">{chore.points ?? 0}</span>
+                        <span className="points-label">pts</span>
+                      </div>
                     </div>
-                    <ICONS.points className="detail-icon" />
                   </div>
 
                   <div className="chore-detail-item icon-only">
                     <div className="detail-content">
-                      <div className="assignment-info">
-                        <span className={`assignment-type ${chore.assignment_type}`}>
-                          {chore.assignment_type}
-                        </span>
+                      <div className="assignment-row">
+                        <div className={`assignment-info ${chore.assignment_type}`}>
+                          <ICONS.assignee className="assignment-icon" />
+                          <span className="assignment-type">
+                            {chore.assignment_type}
+                          </span>
+                        </div>
                         <span className="assignee-name">{assigneeLabel}</span>
                       </div>
                     </div>
-                    <ICONS.assignee className="detail-icon" />
                   </div>
                 </div>
               </div>
-
               {chore.next_due && (
                 <div className="chore-right">
                   <div className="due-content">

--- a/frontend/src/components/ChoreList.jsx
+++ b/frontend/src/components/ChoreList.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { getChores, getPeople } from "../api/client";
 import { MdSchedule, MdPerson, MdStar, MdEdit, MdDelete, MdAccessTime } from "react-icons/md";
+import { getChoreAssigneeLabel } from "../utils/choreAssignee";
 import { compareChoresByNextDue } from "../utils/choreSort";
 import "./ChoreList.css";
 
@@ -42,94 +43,90 @@ export default function ChoreList({ onEdit, onDelete, chores: externalChores, pe
 
   return (
     <div className="chore-list" role="region" aria-label="Chores list">
-      {sorted.map((chore) => (
-        <article key={chore.id} className="chore-card" onClick={() => setExpandedChoreId(expandedChoreId === chore.id ? null : chore.id)}>
-          <div className="chore-content">
-            <div className="chore-left">
-              <div className="chore-header">
-                <h3 className="chore-name">{chore.name}</h3>
-              </div>
+      {sorted.map((chore) => {
+        const assigneeLabel = getChoreAssigneeLabel(chore);
 
-              <div className="chore-details">
-                <div className="chore-detail-item icon-only">
-                  <div className="detail-content">
-                    <span className="detail-value">{chore.points ?? 0}</span>
-                  </div>
-                  <ICONS.points className="detail-icon" />
+        return (
+          <article key={chore.id} className="chore-card" onClick={() => setExpandedChoreId(expandedChoreId === chore.id ? null : chore.id)}>
+            <div className="chore-content">
+              <div className="chore-left">
+                <div className="chore-header">
+                  <h3 className="chore-name">{chore.name}</h3>
                 </div>
 
-                <div className="chore-detail-item icon-only">
-                  <div className="detail-content">
-                    <div className="assignment-info">
-                      {chore.assignment_type === "fixed" && chore.assignee ? (
-                        <span className="assignee-name">{chore.assignee}</span>
-                      ) : (
-                        <>
-                          <span className={`assignment-type ${chore.assignment_type}`}>
-                            {chore.assignment_type}
-                          </span>
-                          {chore.current_assignee && (
-                            <span className="assignee-name">{chore.current_assignee}</span>
-                          )}
-                        </>
-                      )}
+                <div className="chore-details">
+                  <div className="chore-detail-item icon-only">
+                    <div className="detail-content">
+                      <span className="detail-value">{chore.points ?? 0}</span>
                     </div>
+                    <ICONS.points className="detail-icon" />
                   </div>
-                  <ICONS.assignee className="detail-icon" />
+
+                  <div className="chore-detail-item icon-only">
+                    <div className="detail-content">
+                      <div className="assignment-info">
+                        <span className={`assignment-type ${chore.assignment_type}`}>
+                          {chore.assignment_type}
+                        </span>
+                        <span className="assignee-name">{assigneeLabel}</span>
+                      </div>
+                    </div>
+                    <ICONS.assignee className="detail-icon" />
+                  </div>
                 </div>
               </div>
+
+              {chore.next_due && (
+                <div className="chore-right">
+                  <div className="due-content">
+                    <div className="due-value">
+                      {new Date(chore.next_due + "T00:00:00").toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </div>
+                    <div className="due-label">{chore.schedule_summary}</div>
+                  </div>
+                  <MdAccessTime className="due-icon" />
+                </div>
+              )}
             </div>
 
-            {chore.next_due && (
-              <div className="chore-right">
-                <div className="due-content">
-                  <div className="due-value">
-                    {new Date(chore.next_due + "T00:00:00").toLocaleDateString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                    })}
-                  </div>
-                  <div className="due-label">{chore.schedule_summary}</div>
-                </div>
-                <MdAccessTime className="due-icon" />
-              </div>
-            )}
-          </div>
-
-          <div className={`chore-actions ${expandedChoreId === chore.id ? "expanded" : ""}`}>
-            <button
-              className="chore-action-link"
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit?.(chore);
-              }}
-              aria-label={`Edit ${chore.name}`}
-            >
-              Edit
-            </button>
-            <button
-              className="chore-action-link"
-              onClick={(e) => {
-                e.stopPropagation();
-                navigate(`/log?chore_id=${encodeURIComponent(chore.id)}`);
-              }}
-              aria-label={`History for ${chore.name}`}
-            >
-              History
-            </button>
-            <button
-              className="chore-action-link chore-action-delete"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete?.(chore);
-              }}
-              aria-label={`Delete ${chore.name}`}
-            >
-              Delete
-            </button>
-          </div>
-        </article>
-      ))}
+            <div className={`chore-actions ${expandedChoreId === chore.id ? "expanded" : ""}`}>
+              <button
+                className="chore-action-link"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit?.(chore);
+                }}
+                aria-label={`Edit ${chore.name}`}
+              >
+                Edit
+              </button>
+              <button
+                className="chore-action-link"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(`/log?chore_id=${encodeURIComponent(chore.id)}`);
+                }}
+                aria-label={`History for ${chore.name}`}
+              >
+                History
+              </button>
+              <button
+                className="chore-action-link chore-action-delete"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete?.(chore);
+                }}
+                aria-label={`Delete ${chore.name}`}
+              >
+                Delete
+              </button>
+            </div>
+          </article>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/pages/Manage.jsx
+++ b/frontend/src/pages/Manage.jsx
@@ -6,6 +6,11 @@ import { getChores, getPeople, createChore, updateChore, deleteChore } from "../
 import ChoreForm from "../components/ChoreForm";
 import ChoreList from "../components/ChoreList";
 import Modal from "../components/Modal";
+import {
+  getChoreAssigneeName,
+  UNASSIGNED_FILTER_VALUE,
+  UNASSIGNED_LABEL,
+} from "../utils/choreAssignee";
 import { compareChoresByNextDue } from "../utils/choreSort";
 import "./Manage.css";
 
@@ -15,12 +20,14 @@ function getFiltersFromSearchParams(searchParams) {
   const assignmentType = searchParams.get("assignment_type");
   const state = searchParams.get("state");
   const disabled = searchParams.get("disabled");
+  const assignee = searchParams.get("assignee");
 
   if (scheduleType) filters.schedule_type = scheduleType;
   if (assignmentType) filters.assignment_type = assignmentType;
   if (state) filters.state = state;
   if (disabled === "true") filters.disabled = true;
   if (disabled === "false") filters.disabled = false;
+  if (assignee) filters.assignee = assignee;
 
   return filters;
 }
@@ -85,6 +92,11 @@ export default function Manage() {
       if (filters.assignment_type && chore.assignment_type !== filters.assignment_type) return false;
       if (filters.state && chore.state !== filters.state) return false;
       if (filters.disabled !== undefined && chore.disabled !== filters.disabled) return false;
+      if (filters.assignee) {
+        const assignee = getChoreAssigneeName(chore);
+        if (filters.assignee === UNASSIGNED_FILTER_VALUE) return assignee === null;
+        if (assignee !== filters.assignee) return false;
+      }
       return true;
     });
   }, [chores, filters]);
@@ -93,6 +105,7 @@ export default function Manage() {
 
   const scheduleTypes = [...new Set(chores.map(c => c.schedule_type))].sort();
   const assignmentTypes = [...new Set(chores.map(c => c.assignment_type))].sort();
+  const assignees = [...new Set(chores.map(getChoreAssigneeName).filter(Boolean))].sort();
   const states = [...new Set(chores.map(c => c.state))].sort();
 
   return (
@@ -154,6 +167,23 @@ export default function Manage() {
                       {type}
                     </option>
                   ))}
+                </select>
+              </div>
+
+              <div className="filter-group">
+                <label htmlFor="filter-assignee">Assignee</label>
+                <select
+                  id="filter-assignee"
+                  value={filters.assignee || ""}
+                  onChange={(e) => handleFilterChange("assignee", e.target.value)}
+                >
+                  <option value="">All assignees</option>
+                  {assignees.map((assignee) => (
+                    <option key={assignee} value={assignee}>
+                      {assignee}
+                    </option>
+                  ))}
+                  <option value={UNASSIGNED_FILTER_VALUE}>{UNASSIGNED_LABEL}</option>
                 </select>
               </div>
 

--- a/frontend/src/utils/choreAssignee.js
+++ b/frontend/src/utils/choreAssignee.js
@@ -1,0 +1,14 @@
+export const UNASSIGNED_FILTER_VALUE = "unassigned";
+export const UNASSIGNED_LABEL = "Unassigned";
+
+export function getChoreAssigneeName(chore) {
+  if (chore.assignment_type === "fixed") {
+    return chore.assignee || chore.current_assignee || null;
+  }
+
+  return chore.current_assignee || null;
+}
+
+export function getChoreAssigneeLabel(chore) {
+  return getChoreAssigneeName(chore) || UNASSIGNED_LABEL;
+}


### PR DESCRIPTION
## Summary
- show a clear assignee label on each /chores card for fixed, rotating, and open chores
- add an assignee filter to /chores using the existing URL-backed filter pattern
- support filtering for both named assignees and unassigned chores

Closes #31

## Testing
- npm test -- --run src/__tests__/Manage.test.jsx
- npm test -- --run src/__tests__/ChoreList.test.jsx