### PR TITLE
feat: Replace dashboard due-soon lists with links to filtered chores views

### DIFF
--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -80,15 +80,17 @@ describe("Dashboard", () => {
 
   it("shows Open section for unassigned due chores", async () => {
     wrap(<Dashboard />);
-    await waitFor(() => expect(screen.getByText("Open / Unassigned")).toBeInTheDocument());
-    expect(screen.getByText("Take out trash")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Alice", { selector: ".uc-name" })).toBeInTheDocument());
+    // Open/Unassigned section shows a count (1 in this case) as a clickable link
+    const openTitle = screen.getByText("Open / Unassigned", { selector: ".open-section-title" });
+    expect(openTitle).toBeInTheDocument();
   });
 
   it("does not show Open section when no open chores", async () => {
     client.getChores.mockResolvedValue([CHORES[0]]);
     wrap(<Dashboard />);
     await waitFor(() => screen.getByText("Alice", { selector: ".uc-name" }));
-    expect(screen.queryByText("Open / Unassigned")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open / Unassigned", { selector: ".open-section-title" })).not.toBeInTheDocument();
   });
 
   it("shows empty state when no people", async () => {
@@ -122,6 +124,34 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("location")).toHaveTextContent("/users/Alice");
+    });
+  });
+
+  it("navigates to filtered chores view when clicking Open/Unassigned button", async () => {
+    wrap(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <Dashboard />
+              <LocationDisplay />
+            </>
+          }
+        />
+        <Route path="/chores" element={<LocationDisplay />} />
+      </Routes>
+    );
+    await waitFor(() => {
+      const openTitle = screen.getByText("Open / Unassigned", { selector: ".open-section-title" });
+      expect(openTitle).toBeInTheDocument();
+    });
+
+    const openButton = screen.getByText("Open / Unassigned", { selector: ".open-section-title" }).closest("button");
+    fireEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent(/\/chores/);
     });
   });
 });

--- a/frontend/src/__tests__/UserCard.test.jsx
+++ b/frontend/src/__tests__/UserCard.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 import UserCard from "../components/UserCard";
 import * as client from "../api/client";
 
@@ -49,16 +50,16 @@ const SUMMARY = { person: "Alice", points_7d: 10, points_30d: 25 };
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 describe("UserCard", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    client.completeChore.mockResolvedValue({ ...DUE_CHORE, state: "complete" });
-    client.skipChore.mockResolvedValue({ ...DUE_CHORE, state: "complete" });
-    client.reassignChore.mockResolvedValue({ ...DUE_CHORE, current_assignee: "Bob" });
-    client.markDueChore.mockResolvedValue({ ...SOON_CHORE, state: "due" });
   });
 
   it("renders person name", () => {
@@ -88,64 +89,53 @@ describe("UserCard", () => {
     expect(screen.getByText("1")).toBeInTheDocument();
   });
 
-  it("shows due now chore name as clickable button", () => {
-    wrap(<UserCard person={PERSON} chores={[DUE_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    // Due chores are shown as buttons that open a modal; chore name is visible
-    expect(screen.getByText("Vacuum")).toBeInTheDocument();
-    // Complete/Skip appear inside the modal after clicking the chore button
-    expect(screen.queryByText("Complete")).not.toBeInTheDocument();
+  it("shows due soon count", () => {
+    wrap(<UserCard person={PERSON} chores={[SOON_CHORE]} people={PEOPLE} summary={SUMMARY} />);
+    const dueSoonHeaders = screen.getAllByText(/Due Soon/i);
+    expect(dueSoonHeaders.length).toBeGreaterThan(0);
+    // Due Soon count should be 1
+    const counts = screen.getAllByText("1");
+    expect(counts.length).toBeGreaterThan(0);
   });
 
-  it("opens modal with Complete and Skip when due chore is clicked", async () => {
+  it("shows open/unassigned count", () => {
+    const openChore = { ...DUE_CHORE, assignment_type: "open", current_assignee: null, id: "open-chore", unique_id: "open-chore" };
+    wrap(<UserCard person={PERSON} chores={[openChore]} people={PEOPLE} summary={SUMMARY} />);
+    expect(screen.getByText("Open / Unassigned")).toBeInTheDocument();
+  });
+
+  it("navigates to due-now filtered chores on Due Now click", async () => {
     wrap(<UserCard person={PERSON} chores={[DUE_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    fireEvent.click(screen.getByText("Vacuum"));
-    await waitFor(() => {
-      expect(screen.getByText("Complete")).toBeInTheDocument();
-      expect(screen.getByText("Skip")).toBeInTheDocument();
+    // Should have "Due Now" link button
+    const dueNowButtons = screen.getAllByRole("button").filter(btn => {
+      const header = btn.querySelector(".uc-due-header");
+      return header && header.textContent === "Due Now";
     });
+    expect(dueNowButtons.length).toBeGreaterThan(0);
   });
 
-  it("due soon section shows chores inline", () => {
+  it("navigates to due-soon filtered chores on Due Soon click", async () => {
     wrap(<UserCard person={PERSON} chores={[SOON_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    // Due soon chores are shown directly via ChoreRowActions with mode="soon"
-    expect(screen.getByText("Dishes")).toBeInTheDocument();
+    // Should have "Due Soon" link button
+    const dueSoonButtons = screen.getAllByRole("button").filter(btn => {
+      const header = btn.querySelector(".uc-due-header");
+      return header && header.textContent === "Due Soon";
+    });
+    expect(dueSoonButtons.length).toBeGreaterThan(0);
   });
 
-  it("shows Mark due button for soon chores", () => {
-    wrap(<UserCard person={PERSON} chores={[SOON_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    // Mark due appears inline for soon chores
-    expect(screen.getByText("Mark due")).toBeInTheDocument();
-  });
-
-  it("calls completeChore with person name on Complete click inside modal", async () => {
-    wrap(<UserCard person={PERSON} chores={[DUE_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    // Open modal by clicking chore name
-    fireEvent.click(screen.getByText("Vacuum"));
-    await waitFor(() => screen.getByText("Complete"));
-    fireEvent.click(screen.getByText("Complete"));
-    await waitFor(() => expect(client.completeChore).toHaveBeenCalledWith("vacuum", "Alice"));
-  });
-
-  it("calls skipChore on Skip click inside modal", async () => {
-    wrap(<UserCard person={PERSON} chores={[DUE_CHORE]} people={PEOPLE} summary={SUMMARY} />);
-    // Open modal by clicking chore name
-    fireEvent.click(screen.getByText("Vacuum"));
-    await waitFor(() => screen.getByText("Skip"));
-    fireEvent.click(screen.getByText("Skip"));
-    await waitFor(() => expect(client.skipChore).toHaveBeenCalledWith("vacuum"));
-  });
-
-  it("excludes chores assigned to other people", () => {
+  it("excludes chores assigned to other people from due count", () => {
     const otherChore = { ...DUE_CHORE, current_assignee: "Bob", unique_id: "other" };
     wrap(<UserCard person={PERSON} chores={[otherChore]} people={PEOPLE} summary={SUMMARY} />);
-    expect(screen.queryByText("Vacuum")).not.toBeInTheDocument();
+    // Due Now count should be 0 for Alice when only Bob's chore is present
+    const counts = screen.getAllByText("0");
+    expect(counts.length).toBeGreaterThan(0);
   });
 
-  it("does not show chores due more than 7 days away in soon section", () => {
+  it("does not count chores due more than 7 days away in soon count", () => {
     const farChore = { ...SOON_CHORE, id: "far", unique_id: "far", next_due: dateStr(10) };
     wrap(<UserCard person={PERSON} chores={[farChore]} people={PEOPLE} summary={SUMMARY} />);
-    // Chore due in 10 days is outside the 7-day window and should not appear
-    expect(screen.queryByText("Dishes")).not.toBeInTheDocument();
+    // Chore due in 10 days is outside the 7-day window and should not be counted
     // Due Soon count should be 0
     const dueSoonHeaders = screen.getAllByText(/Due Soon/i);
     expect(dueSoonHeaders.length).toBeGreaterThan(0);

--- a/frontend/src/components/UserCard.css
+++ b/frontend/src/components/UserCard.css
@@ -88,6 +88,21 @@
   gap: 0.35rem;
 }
 
+.uc-due-link {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.uc-due-link:hover {
+  background-color: var(--surface2);
+  transform: scale(1.02);
+}
+
 .uc-due-header {
   font-size: 0.7rem;
   font-weight: 600;
@@ -124,6 +139,37 @@
 
 .uc-chore-link:hover {
   background-color: var(--surface2);
+}
+
+.uc-workload {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem;
+  background-color: var(--surface2);
+  border-radius: 4px;
+}
+
+.uc-workload-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.uc-workload-count {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--accent);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.uc-workload-count:hover {
+  opacity: 0.8;
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/UserCard.jsx
+++ b/frontend/src/components/UserCard.jsx
@@ -1,8 +1,7 @@
 import React from "react";
-import ChoreRowActions from "./ChoreRowActions";
+import { useNavigate } from "react-router-dom";
 import Avatar from "./Avatar";
 import ProgressBar from "./ProgressBar";
-import Modal from "./Modal";
 import { getPersonColor } from "../utils/personColors";
 import { getTrendStatus, getTrendColor } from "../utils/trendStatus";
 import "./UserCard.css";
@@ -17,7 +16,7 @@ function daysUntil(dateStr) {
 }
 
 export default function UserCard({ person, chores, people, summary }) {
-  const [selectedChore, setSelectedChore] = React.useState(null);
+  const navigate = useNavigate();
   const color = person.color || getPersonColor(person.name);
   const goal7d = person.goal_7d ?? 12;
   const goal30d = person.goal_30d ?? 50;
@@ -34,7 +33,7 @@ export default function UserCard({ person, chores, people, summary }) {
       if (c.assignment_type === "fixed") return c.assignee === person.name;
       return c.current_assignee === person.name;
     })
-    .sort((a, b) => (b.age ?? -999) - (a.age ?? -999));
+    .length;
 
   const dueSoon = chores
     .filter((c) => {
@@ -42,7 +41,11 @@ export default function UserCard({ person, chores, people, summary }) {
       const d = daysUntil(c.next_due);
       return d >= 0 && d <= DUE_SOON_DAYS;
     })
-    .sort((a, b) => daysUntil(a.next_due) - daysUntil(b.next_due));
+    .length;
+
+  const openUnassigned = chores
+    .filter((c) => c.state === "due" && c.assignment_type === "open" && !c.disabled)
+    .length;
 
   return (
     <div className="user-card">
@@ -71,52 +74,41 @@ export default function UserCard({ person, chores, people, summary }) {
       <div className="uc-divider" />
 
       <div className="uc-due-grid">
-        <div className="uc-due-col">
+        <button
+          className="uc-due-col uc-due-link"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/chores?state=due&assignee=${encodeURIComponent(person.name)}`);
+          }}
+        >
           <div className="uc-due-header">Due Now</div>
-          <div className="uc-due-count">{dueNow.length}</div>
-          <div className="uc-due-list">
-            {dueNow.map((chore) => (
-              <button
-                key={chore.id}
-                className="uc-chore-link"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setSelectedChore(chore);
-                }}
-              >
-                {chore.name}
-              </button>
-            ))}
-          </div>
-        </div>
+          <div className="uc-due-count">{dueNow}</div>
+        </button>
 
-        <div className="uc-due-col">
+        <button
+          className="uc-due-col uc-due-link"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/chores?state=complete&assignee=${encodeURIComponent(person.name)}`);
+          }}
+        >
           <div className="uc-due-header">Due Soon</div>
-          <div className="uc-due-count">{dueSoon.length}</div>
-          <div className="uc-due-list">
-            {dueSoon.map((chore) => (
-              <ChoreRowActions
-                key={chore.id}
-                chore={chore}
-                person={person.name}
-                people={people}
-                mode="soon"
-              />
-            ))}
-          </div>
-        </div>
+          <div className="uc-due-count">{dueSoon}</div>
+        </button>
       </div>
 
-      {selectedChore && (
-        <Modal title={selectedChore.name} onClose={() => setSelectedChore(null)}>
-          <ChoreRowActions
-            chore={selectedChore}
-            person={person.name}
-            people={people}
-            mode="due"
-          />
-        </Modal>
-      )}
+      <div className="uc-workload">
+        <div className="uc-workload-label">Open / Unassigned</div>
+        <button
+          className="uc-workload-count"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/chores?state=due&assignment_type=open`);
+          }}
+        >
+          {openUnassigned}
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -19,9 +19,24 @@
 }
 
 .open-section {
+  margin-top: 1rem;
+}
+
+.open-section-link {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.open-section-link:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
 }
 
 .open-section-title {
@@ -30,14 +45,13 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0.5rem;
+  margin: 0;
 }
 
-.open-chore-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+.open-section-count {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--warning);
 }
 
 .dashboard-empty {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { getChores, getPeople, getPointsSummary } from "../api/client";
 import UserCard from "../components/UserCard";
-import ChoreRowActions from "../components/ChoreRowActions";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -27,9 +26,9 @@ export default function Dashboard() {
 
   const summaryByPerson = Object.fromEntries(summary.map((s) => [s.person, s]));
 
-  const openDue = chores
-    .filter((c) => c.state === "due" && c.assignment_type === "open" && !c.disabled)
-    .sort((a, b) => (b.age ?? -999) - (a.age ?? -999));
+  const openDueCount = chores.filter(
+    (c) => c.state === "due" && c.assignment_type === "open" && !c.disabled
+  ).length;
 
   if (isLoading) return <div className="loading">Loading…</div>;
 
@@ -63,20 +62,15 @@ export default function Dashboard() {
         ))}
       </div>
 
-      {openDue.length > 0 && (
+      {openDueCount > 0 && (
         <section className="open-section">
-          <h3 className="open-section-title">Open / Unassigned</h3>
-          <div className="open-chore-list">
-            {openDue.map((chore) => (
-              <ChoreRowActions
-                key={chore.id}
-                chore={chore}
-                person={null}
-                people={people}
-                mode="due"
-              />
-            ))}
-          </div>
+          <button
+            className="open-section-link"
+            onClick={() => navigate(`/chores?state=due&assignment_type=open`)}
+          >
+            <h3 className="open-section-title">Open / Unassigned</h3>
+            <div className="open-section-count">{openDueCount}</div>
+          </button>
         </section>
       )}
     </div>


### PR DESCRIPTION
## Summary
Replaces inline due-now and due-soon chore lists on dashboard cards with navigation links to the filtered `/chores` view, making the dashboard more summary-oriented and moving detailed triage to the full chores view.

## Changes
- UserCard now displays due-now and due-soon counts as clickable links instead of inline lists
- Added open/unassigned chore count button to UserCard 
- Dashboard open/unassigned section replaced with link to filtered chores view
- Chores view already supports query param filters (state, assignee, assignment_type)
- Updated styling for new link components

## Closes
#20

## Testing
- Verify UserCard links navigate to `/chores` with correct filters
- Verify due-now filters by state=due and assignee
- Verify due-soon filters by state=complete and assignee
- Verify open/unassigned link filters by state=due&assignment_type=open
- Verify dashboard open/unassigned button navigates to filtered view

🤖 Generated with [Claude Code](https://claude.com/claude-code)