### PR TITLE
fix(chore-form): set default points to 1 instead of 0

### DIFF
--- a/frontend/src/components/ChoreForm.jsx
+++ b/frontend/src/components/ChoreForm.jsx
@@ -32,7 +32,7 @@ function emptyState() {
     assignee: "",
     current_assignee: "",
     next_assignee: "",
-    points: "0",
+    points: "1",
     disabled: false,
     // dates
     next_due: null,


### PR DESCRIPTION
## Summary

Fix new chore creation defaulting to 0 points despite select showing 1 as first option.

## Root cause

Initial state `points: "0"` didn't match available options (1,2,3,5,8,13). Uncontrolled select left form unable to capture point selection.

## Solution

Change `emptyState()` to initialize `points: "1"` (first FIBONACCI value). Select now properly controlled.

## Testing

- [x] All 235 tests passing
- [x] Form select now displays selected value
- [x] New chores created with 1 point by default

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)