### PR TITLE
feat: Consolidate due now/soon counts to include assigned and unassigned chores (#35)

### DIFF
--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -78,21 +78,6 @@ describe("Dashboard", () => {
     expect(screen.getByText("25")).toBeInTheDocument();
   });
 
-  it("shows Open section for unassigned due chores", async () => {
-    wrap(<Dashboard />);
-    await waitFor(() => expect(screen.getByText("Alice", { selector: ".uc-name" })).toBeInTheDocument());
-    // Open/Unassigned section shows a count (1 in this case) as a clickable link
-    const openTitle = screen.getByText("Open / Unassigned", { selector: ".open-section-title" });
-    expect(openTitle).toBeInTheDocument();
-  });
-
-  it("does not show Open section when no open chores", async () => {
-    client.getChores.mockResolvedValue([CHORES[0]]);
-    wrap(<Dashboard />);
-    await waitFor(() => screen.getByText("Alice", { selector: ".uc-name" }));
-    expect(screen.queryByText("Open / Unassigned", { selector: ".open-section-title" })).not.toBeInTheDocument();
-  });
-
   it("shows empty state when no people", async () => {
     client.getPeople.mockResolvedValue([]);
     client.getPointsSummary.mockResolvedValue([]);
@@ -124,34 +109,6 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("location")).toHaveTextContent("/users/Alice");
-    });
-  });
-
-  it("navigates to filtered chores view when clicking Open/Unassigned button", async () => {
-    wrap(
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <>
-              <Dashboard />
-              <LocationDisplay />
-            </>
-          }
-        />
-        <Route path="/chores" element={<LocationDisplay />} />
-      </Routes>
-    );
-    await waitFor(() => {
-      const openTitle = screen.getByText("Open / Unassigned", { selector: ".open-section-title" });
-      expect(openTitle).toBeInTheDocument();
-    });
-
-    const openButton = screen.getByText("Open / Unassigned", { selector: ".open-section-title" }).closest("button");
-    fireEvent.click(openButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent(/\/chores/);
     });
   });
 });

--- a/frontend/src/__tests__/UserCard.test.jsx
+++ b/frontend/src/__tests__/UserCard.test.jsx
@@ -98,12 +98,6 @@ describe("UserCard", () => {
     expect(counts.length).toBeGreaterThan(0);
   });
 
-  it("shows open/unassigned count", () => {
-    const openChore = { ...DUE_CHORE, assignment_type: "open", current_assignee: null, id: "open-chore", unique_id: "open-chore" };
-    wrap(<UserCard person={PERSON} chores={[openChore]} people={PEOPLE} summary={SUMMARY} />);
-    expect(screen.getByText("Open / Unassigned")).toBeInTheDocument();
-  });
-
   it("navigates to due-now filtered chores on Due Now click", async () => {
     wrap(<UserCard person={PERSON} chores={[DUE_CHORE]} people={PEOPLE} summary={SUMMARY} />);
     // Should have "Due Now" link button

--- a/frontend/src/components/UserCard.jsx
+++ b/frontend/src/components/UserCard.jsx
@@ -4,6 +4,7 @@ import Avatar from "./Avatar";
 import ProgressBar from "./ProgressBar";
 import { getPersonColor } from "../utils/personColors";
 import { getTrendStatus, getTrendColor } from "../utils/trendStatus";
+import { UNASSIGNED_FILTER_VALUE } from "../utils/choreAssignee";
 import "./UserCard.css";
 
 const DUE_SOON_DAYS = 7;
@@ -31,20 +32,20 @@ export default function UserCard({ person, chores, people, summary }) {
     .filter((c) => {
       if (c.state !== "due" || c.disabled) return false;
       if (c.assignment_type === "fixed") return c.assignee === person.name;
+      if (c.assignment_type === "open") return c.current_assignee === null || c.current_assignee === person.name;
       return c.current_assignee === person.name;
     })
     .length;
 
   const dueSoon = chores
     .filter((c) => {
-      if (c.current_assignee !== person.name || c.state !== "complete" || !c.next_due || c.disabled) return false;
+      if (c.state !== "complete" || !c.next_due || c.disabled) return false;
       const d = daysUntil(c.next_due);
-      return d >= 0 && d <= DUE_SOON_DAYS;
+      if (d < 0 || d > DUE_SOON_DAYS) return false;
+      if (c.assignment_type === "fixed") return c.assignee === person.name;
+      if (c.assignment_type === "open") return c.current_assignee === null || c.current_assignee === person.name;
+      return c.current_assignee === person.name;
     })
-    .length;
-
-  const openUnassigned = chores
-    .filter((c) => c.state === "due" && c.assignment_type === "open" && !c.disabled)
     .length;
 
   return (
@@ -78,35 +79,29 @@ export default function UserCard({ person, chores, people, summary }) {
           className="uc-due-col uc-due-link"
           onClick={(e) => {
             e.stopPropagation();
-            navigate(`/chores?state=due&assignee=${encodeURIComponent(person.name)}`);
+            const params = new URLSearchParams();
+            params.append("state", "due");
+            params.append("assignee", person.name);
+            params.append("assignee", UNASSIGNED_FILTER_VALUE);
+            navigate(`/chores?${params.toString()}`);
           }}
         >
           <div className="uc-due-header">Due Now</div>
-          <div className="uc-due-count">{dueNow}</div>
+          <div className="uc-due-count" style={dueNow === 0 ? { color: "var(--text)" } : {}}>{dueNow}</div>
         </button>
 
         <button
           className="uc-due-col uc-due-link"
           onClick={(e) => {
             e.stopPropagation();
-            navigate(`/chores?state=complete&assignee=${encodeURIComponent(person.name)}`);
+            const params = new URLSearchParams();
+            params.append("assignee", person.name);
+            params.append("assignee", UNASSIGNED_FILTER_VALUE);
+            navigate(`/chores?${params.toString()}`);
           }}
         >
           <div className="uc-due-header">Due Soon</div>
-          <div className="uc-due-count">{dueSoon}</div>
-        </button>
-      </div>
-
-      <div className="uc-workload">
-        <div className="uc-workload-label">Open / Unassigned</div>
-        <button
-          className="uc-workload-count"
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate(`/chores?state=due&assignment_type=open`);
-          }}
-        >
-          {openUnassigned}
+          <div className="uc-due-count" style={dueSoon === 0 ? { color: "var(--text)" } : {}}>{dueSoon}</div>
         </button>
       </div>
     </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -26,10 +26,6 @@ export default function Dashboard() {
 
   const summaryByPerson = Object.fromEntries(summary.map((s) => [s.person, s]));
 
-  const openDueCount = chores.filter(
-    (c) => c.state === "due" && c.assignment_type === "open" && !c.disabled
-  ).length;
-
   if (isLoading) return <div className="loading">Loading…</div>;
 
   if (people.length === 0) {
@@ -61,18 +57,6 @@ export default function Dashboard() {
           </div>
         ))}
       </div>
-
-      {openDueCount > 0 && (
-        <section className="open-section">
-          <button
-            className="open-section-link"
-            onClick={() => navigate(`/chores?state=due&assignment_type=open`)}
-          >
-            <h3 className="open-section-title">Open / Unassigned</h3>
-            <div className="open-section-count">{openDueCount}</div>
-          </button>
-        </section>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Consolidates Due Now and Due Soon counts to include both assigned and unassigned chores for each user. Removes the separate Open/Unassigned section from dashboard and user cards, simplifying navigation.

## Changes
- Due Now count includes both assigned chores AND unassigned chores
- Due Soon count includes both assigned chores AND unassigned chores
- Remove Open/Unassigned link section from user cards
- Remove Open/Unassigned section from dashboard
- Zero counts display in default text color instead of warning color
- Navigation links filter by assigned person AND unassigned for accurate results

## Test Plan
- ✓ All 241 tests pass
- ✓ Dashboard no longer shows Open/Unassigned section
- ✓ User cards show consolidated counts
- ✓ Due Now/Due Soon links navigate with correct filters
- ✓ Zero counts display without warning color

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)