### PR TITLE
feat: Add assignment validation function (#61)

### DIFF
--- a/backend/app/services/chore_service.py
+++ b/backend/app/services/chore_service.py
@@ -27,6 +27,47 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def validate_assignment(chore) -> Optional[dict[str, str]]:
+    """Validate chore assignment configuration.
+
+    Returns None if valid, dict of field->error message if invalid.
+    """
+    if isinstance(chore, dict):
+        assignment_type = chore.get('assignment_type')
+        current_assignee = chore.get('current_assignee')
+        assignee = chore.get('assignee')
+        eligible_people = chore.get('eligible_people') or []
+        next_assignee = chore.get('next_assignee')
+    else:
+        assignment_type = chore.assignment_type
+        current_assignee = chore.current_assignee
+        assignee = chore.assignee
+        eligible_people = chore.eligible_people or []
+        next_assignee = getattr(chore, 'next_assignee', None)
+
+    if assignment_type == "open":
+        return None
+
+    errors = {}
+
+    if assignment_type == "fixed":
+        if not assignee:
+            errors["assignee"] = "Fixed assignment requires an assignee"
+        elif current_assignee != assignee:
+            errors["current_assignee"] = f"Must be assigned to {assignee} for fixed assignment"
+
+    elif assignment_type == "rotating":
+        if not eligible_people:
+            errors["eligible_people"] = "Rotating assignment requires at least one eligible person"
+        else:
+            if current_assignee and current_assignee not in eligible_people:
+                errors["current_assignee"] = "Not in eligible people list"
+            if next_assignee and next_assignee not in eligible_people:
+                errors["next_assignee"] = "Not in eligible people list"
+
+    return errors if errors else None
+
+
 def compute_age(chore: Chore) -> Optional[int]:
     if chore.next_due is None:
         return None

--- a/backend/tests/test_chore_service.py
+++ b/backend/tests/test_chore_service.py
@@ -14,6 +14,7 @@ from app.services.chore_service import (
     skip_and_reassign_chore,
     skip_chore,
     transition_overdue_chores,
+    validate_assignment,
 )
 
 
@@ -73,6 +74,112 @@ class TestComputeNextAssignee:
     def test_non_rotating_returns_none(self):
         chore = _make_chore(assignment_type="open")
         assert compute_next_assignee(chore) is None
+
+
+class TestValidateAssignment:
+    def test_open_assignment_always_valid(self):
+        chore = _make_chore(assignment_type="open")
+        assert validate_assignment(chore) is None
+
+    def test_fixed_assignment_valid(self):
+        chore = _make_chore(
+            assignment_type="fixed",
+            assignee="Alice",
+            current_assignee="Alice",
+        )
+        assert validate_assignment(chore) is None
+
+    def test_fixed_assignment_mismatched_current(self):
+        chore = _make_chore(
+            assignment_type="fixed",
+            assignee="Alice",
+            current_assignee="Bob",
+        )
+        errors = validate_assignment(chore)
+        assert errors is not None
+        assert "current_assignee" in errors
+
+    def test_fixed_assignment_missing_assignee(self):
+        chore = _make_chore(
+            assignment_type="fixed",
+            assignee=None,
+            current_assignee="Alice",
+        )
+        errors = validate_assignment(chore)
+        assert errors is not None
+        assert "assignee" in errors
+
+    def test_rotating_assignment_valid(self):
+        chore = _make_chore(
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob", "Carol"],
+            current_assignee="Alice",
+        )
+        assert validate_assignment(chore) is None
+
+    def test_rotating_assignment_invalid_current(self):
+        chore = _make_chore(
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob"],
+            current_assignee="Carol",
+        )
+        errors = validate_assignment(chore)
+        assert errors is not None
+        assert "current_assignee" in errors
+
+    def test_rotating_assignment_invalid_next(self):
+        chore = _make_chore(
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob"],
+            current_assignee="Alice",
+        )
+        # Add next_assignee to dict representation for validation
+        errors = validate_assignment({
+            "assignment_type": "rotating",
+            "eligible_people": ["Alice", "Bob"],
+            "current_assignee": "Alice",
+            "next_assignee": "Carol",
+        })
+        assert errors is not None
+        assert "next_assignee" in errors
+
+    def test_rotating_assignment_empty_eligible(self):
+        chore = _make_chore(
+            assignment_type="rotating",
+            eligible_people=[],
+            current_assignee=None,
+        )
+        errors = validate_assignment(chore)
+        assert errors is not None
+        assert "eligible_people" in errors
+
+    def test_rotating_assignment_null_current_assignee(self):
+        chore = _make_chore(
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob"],
+            current_assignee=None,
+        )
+        assert validate_assignment(chore) is None
+
+    def test_works_with_dict(self):
+        chore_dict = {
+            "assignment_type": "fixed",
+            "assignee": "Alice",
+            "current_assignee": "Alice",
+            "eligible_people": [],
+        }
+        assert validate_assignment(chore_dict) is None
+
+    def test_dict_invalid_fixed(self):
+        chore_dict = {
+            "assignment_type": "fixed",
+            "assignee": "Alice",
+            "current_assignee": "Bob",
+            "eligible_people": [],
+        }
+        errors = validate_assignment(chore_dict)
+        assert errors is not None
+        assert "current_assignee" in errors
 
 
 class TestApplyAssignmentState:


### PR DESCRIPTION
## Summary
Create reusable `validate_assignment()` function in backend/app/services/chore_service.py that validates chore assignment configurations.

- Validates fixed assignments: current_assignee must match assignee
- Validates rotating assignments: current_assignee and next_assignee must be in eligible_people
- Open assignments skip validation
- Returns None if valid, dict of field->error messages if invalid
- Works with both Chore objects and dict inputs
- 11 comprehensive test cases covering all assignment types and edge cases

## Test plan
- [x] All 136 backend tests pass
- [x] New TestValidateAssignment class with 11 tests
- [x] Tests cover: open, fixed (valid/invalid), rotating (valid/invalid), edge cases
- [x] Tests verify both object and dict inputs

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)