### PR TITLE
fix: Allow unassigning chores by preserving explicit null values

### DIFF
--- a/backend/app/routers/chores.py
+++ b/backend/app/routers/chores.py
@@ -178,15 +178,17 @@ async def create_chore(body: ChoreCreate, current_user: str = Depends(get_curren
 @router.put("/{chore_id}", response_model=ChoreOut)
 async def update_chore(chore_id: int, body: ChoreUpdate, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     chore = await _get_or_404(chore_id, db)
-    updates = body.model_dump(exclude_none=True)
-    current_assignee = updates.pop("current_assignee", None)
-    next_assignee = updates.pop("next_assignee", None)
+    updates = body.model_dump(exclude_unset=True)
+    has_current_assignee = "current_assignee" in updates
+    has_next_assignee = "next_assignee" in updates
+    current_assignee = updates.pop("current_assignee", chore.current_assignee) if has_current_assignee else chore.current_assignee
+    next_assignee = updates.pop("next_assignee", chore.next_assignee if hasattr(chore, "next_assignee") else None) if has_next_assignee else None
     target_assignment_type = updates.get("assignment_type", chore.assignment_type)
     target_eligible_people = updates.get("eligible_people", chore.eligible_people)
     target_assignee = updates.get("assignee", chore.assignee)
-    target_current_assignee = current_assignee if current_assignee is not None else chore.current_assignee
+    target_current_assignee = current_assignee
 
-    if target_assignment_type == "fixed" and updates.get("assignee") is not None and current_assignee is None:
+    if target_assignment_type == "fixed" and updates.get("assignee") is not None:
         target_current_assignee = updates["assignee"]
 
     people_to_validate = updates.get("eligible_people")
@@ -242,8 +244,11 @@ async def update_chore(chore_id: int, body: ChoreUpdate, current_user: str = Dep
 
         setattr(chore, field, value)
 
-    if target_assignment_type == "fixed" and updates.get("assignee") is not None and current_assignee is None:
+    if target_assignment_type == "fixed" and updates.get("assignee") is not None:
         current_assignee = updates["assignee"]
+
+    if has_current_assignee:
+        chore.current_assignee = current_assignee
 
     if current_assignee is not None or next_assignee is not None or any(
         key in updates for key in ("assignment_type", "eligible_people", "assignee")
@@ -257,7 +262,7 @@ async def update_chore(chore_id: int, body: ChoreUpdate, current_user: str = Dep
             assignment_type=target_assignment_type,
             eligible_people=target_eligible_people,
             assignee=target_assignee,
-            current_assignee=current_assignee,
+            current_assignee=current_assignee if current_assignee is not None else chore.current_assignee,
             next_assignee=next_assignee,
         )
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -185,6 +185,42 @@ class TestChoresAPI:
         assert data["rotation_index"] == 1
 
     @pytest.mark.asyncio
+    async def test_unassign_open_chore(self, authenticated_client):
+        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        create_r = await authenticated_client.post(
+            "/chores",
+            json={
+                "name": "Dishes",
+                "schedule_type": "weekly",
+                "schedule_config": {"days": [0]},
+                "assignment_type": "open",
+                "points": 1,
+            },
+        )
+        chore_id = create_r.json()["id"]
+
+        # Assign to Alice
+        r = await authenticated_client.put(
+            f"/chores/{chore_id}",
+            json={"current_assignee": "Alice"},
+        )
+        assert r.status_code == 200
+        assert r.json()["current_assignee"] == "Alice"
+
+        # Unassign (set to null)
+        r = await authenticated_client.put(
+            f"/chores/{chore_id}",
+            json={"current_assignee": None},
+        )
+        assert r.status_code == 200
+        assert r.json()["current_assignee"] is None
+
+        # Verify by fetching chore again
+        r = await authenticated_client.get(f"/chores/{chore_id}")
+        assert r.status_code == 200
+        assert r.json()["current_assignee"] is None
+
+    @pytest.mark.asyncio
     async def test_update_next_due_from_past_to_future_resets_state_to_complete(self, authenticated_client):
         from datetime import date, timedelta
 


### PR DESCRIPTION
## Summary
Fix unassigning chores (setting current_assignee to null) by properly preserving explicit null values in API requests.

## Problem
- Pydantic's `model_dump(exclude_none=True)` filters out null values
- Backend couldn't distinguish between "field not provided" vs "field explicitly set to null"
- Result: unassigning open chores didn't work

## Solution
1. Use `exclude_unset=True` instead to preserve explicit nulls
2. Track which fields were explicitly in request (`has_current_assignee`)
3. Directly set `chore.current_assignee = None` when explicitly provided
4. Add test to verify unassignment persists after GET

## Test
New test `test_unassign_open_chore`: assigns → unassigns → verifies with GET request

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)