### PR TITLE
feat: Add points field to Person model and admin update API (#84)

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,6 +20,7 @@ class Person(Base):
     color: Mapped[str] = mapped_column(Text, nullable=False, default="#004272")
     goal_7d: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
     goal_30d: Mapped[int] = mapped_column(Integer, nullable=False, default=80)
+    points: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     preferred_theme: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
 

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -53,12 +53,17 @@ async def update_person(person_id: int, body: PersonUpdate, current_user: str = 
         if existing.scalar_one_or_none():
             raise HTTPException(status_code=409, detail="Username already exists")
 
+    # Validate points are non-negative
+    if body.points is not None and body.points < 0:
+        raise HTTPException(status_code=400, detail="Points must be non-negative")
+
     updates = {
         "name": body.name,
         "username": body.username,
         "color": body.color,
         "goal_7d": body.goal_7d,
         "goal_30d": body.goal_30d,
+        "points": body.points,
         "is_admin": body.is_admin,
     }
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -49,6 +49,7 @@ class PersonUpdate(BaseModel):
     color: Optional[str] = None
     goal_7d: Optional[int] = None
     goal_30d: Optional[int] = None
+    points: Optional[int] = None
     is_admin: Optional[bool] = None
     preferred_theme: Optional[str] = None
     password: Optional[str] = None
@@ -62,6 +63,7 @@ class PersonOut(BaseModel):
     color: str
     goal_7d: int
     goal_30d: int
+    points: int
     preferred_theme: Optional[str] = None
 
     model_config = {"from_attributes": True}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -87,6 +87,42 @@ class TestPeopleAPI:
         r = await authenticated_client.post("/people", json={"name": "Frank", "username": "eve123"})
         assert r.status_code == 409  # Conflict - duplicate username
 
+    @pytest.mark.asyncio
+    async def test_person_has_points_field_with_default(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "George", "username": "george123"})
+        assert r.status_code == 201
+        data = r.json()
+        assert "points" in data
+        assert data["points"] == 0
+
+    @pytest.mark.asyncio
+    async def test_admin_can_update_points(self, authenticated_client):
+        create_r = await authenticated_client.post("/people", json={"name": "Helen", "username": "helen"})
+        person_id = create_r.json()["id"]
+
+        r = await authenticated_client.put(f"/people/{person_id}", json={"points": 100})
+        assert r.status_code == 200
+        assert r.json()["points"] == 100
+
+    @pytest.mark.asyncio
+    async def test_negative_points_rejected(self, authenticated_client):
+        create_r = await authenticated_client.post("/people", json={"name": "Ivan", "username": "ivan"})
+        person_id = create_r.json()["id"]
+
+        r = await authenticated_client.put(f"/people/{person_id}", json={"points": -10})
+        assert r.status_code == 400
+        assert "non-negative" in r.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_points_persists_after_update(self, authenticated_client):
+        create_r = await authenticated_client.post("/people", json={"name": "Jack", "username": "jack"})
+        person_id = create_r.json()["id"]
+
+        await authenticated_client.put(f"/people/{person_id}", json={"points": 50})
+        r = await authenticated_client.get(f"/people")
+        person = next(p for p in r.json() if p["id"] == person_id)
+        assert person["points"] == 50
+
 
 class TestChoresAPI:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Add points column to Person model to track user point balances. Admins can update points via PUT endpoint with validation.

- Person model: added points column (INTEGER, NOT NULL, DEFAULT 0)
- PersonOut schema: includes points in response
- PersonUpdate schema: accepts optional points field
- PUT /people/{person_id}: validates points >= 0, admin-only via require_admin dependency
- 4 tests: default value, admin update, negative validation, persistence

## Test plan
- [x] All 162 backend tests pass
- [x] Admin can update user points
- [x] Non-admin cannot update points (already enforced)
- [x] Negative points rejected with validation error
- [x] Points persist across requests

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)