### PR TITLE
fix: UserAvatarMenu dropdown z-index behind chores cards (#76)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -29,6 +29,7 @@
   position: fixed;
   left: 0;
   top: 0;
+  z-index: 100;
 }
 
 .app-sidebar.closed {


### PR DESCRIPTION
## Summary
Add z-index to sidebar to ensure avatar menu dropdown appears above page content.

## Problem
UserAvatarMenu dropdown appeared but was hidden behind chore cards due to stacking context issue.

## Solution
Added `z-index: 100` to `.app-sidebar` to establish proper stacking context. Sidebar is fixed position, so z-index ensures all children (including dropdown) appear above main content.

## Test plan
- [x] All 162 backend tests pass
- [x] Collapse sidebar on /chores, click avatar dropdown
- [x] Dropdown visible and usable above chore cards
- [x] Works at all viewport sizes

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)