### PR TITLE
feat: Add redemption history display in user detail

### DIFF
--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database import get_db
 from ..models import Person, RedemptionLog
-from ..schemas import PersonCreate, PersonOut, PersonUpdate, PersonRedemption
+from ..schemas import PersonCreate, PersonOut, PersonUpdate, PersonRedemption, RedemptionLogOut
 from ..dependencies import get_current_user, require_admin
 from ..security import hash_password
 
@@ -111,3 +111,18 @@ async def redeem_points(person_id: int, body: PersonRedemption, current_user: st
     await db.commit()
     await db.refresh(person)
     return person
+
+
+@router.get("/{person_id}/redemptions", response_model=list[RedemptionLogOut])
+async def get_redemption_history(person_id: int, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Person).where(Person.id == person_id))
+    person = result.scalar_one_or_none()
+    if not person:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+    redemptions_result = await db.execute(
+        select(RedemptionLog)
+        .where(RedemptionLog.person_id == person_id)
+        .order_by(RedemptionLog.timestamp.desc())
+    )
+    return redemptions_result.scalars().all()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -149,6 +149,81 @@ class TestPeopleAPI:
         person = next(p for p in people_r.json() if p["id"] == person_id)
         assert person["points"] == 60
 
+    @pytest.mark.asyncio
+    async def test_redemption_history_empty(self, authenticated_client):
+        create_r = await authenticated_client.post("/people", json={"name": "Karen", "username": "karen"})
+        person_id = create_r.json()["id"]
+
+        r = await authenticated_client.get(f"/people/{person_id}/redemptions")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    @pytest.mark.asyncio
+    async def test_redemption_history_not_found(self, authenticated_client):
+        r = await authenticated_client.get(f"/people/999/redemptions")
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_redemption_history_after_redemption(self, authenticated_client):
+        person_r = await authenticated_client.post("/people", json={"name": "Laura", "username": "laura"})
+        person_id = person_r.json()["id"]
+
+        # Create and complete chore to earn points
+        chore_r = await authenticated_client.post("/chores", json={
+            "name": "Test",
+            "schedule_type": "interval",
+            "schedule_config": {"days": 1},
+            "points": 50
+        })
+        chore_id = chore_r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Laura"})
+
+        # Redeem points
+        redeem_r = await authenticated_client.post(
+            f"/people/{person_id}/redeem",
+            json={"amount": 25}
+        )
+        assert redeem_r.status_code == 200
+
+        # Get history
+        history_r = await authenticated_client.get(f"/people/{person_id}/redemptions")
+        assert history_r.status_code == 200
+        redemptions = history_r.json()
+        assert len(redemptions) == 1
+        assert redemptions[0]["amount"] == 25
+        assert redemptions[0]["person_id"] == person_id
+        assert "redeemed_by" in redemptions[0]
+        assert "timestamp" in redemptions[0]
+
+    @pytest.mark.asyncio
+    async def test_redemption_history_sorted_by_timestamp(self, authenticated_client):
+        person_r = await authenticated_client.post("/people", json={"name": "Mike", "username": "mike"})
+        person_id = person_r.json()["id"]
+
+        # Create and complete chore to earn points
+        chore_r = await authenticated_client.post("/chores", json={
+            "name": "Test",
+            "schedule_type": "interval",
+            "schedule_config": {"days": 1},
+            "points": 100
+        })
+        chore_id = chore_r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Mike"})
+
+        # Multiple redemptions
+        await authenticated_client.post(f"/people/{person_id}/redeem", json={"amount": 10})
+        await authenticated_client.post(f"/people/{person_id}/redeem", json={"amount": 20})
+        await authenticated_client.post(f"/people/{person_id}/redeem", json={"amount": 15})
+
+        # Get history
+        history_r = await authenticated_client.get(f"/people/{person_id}/redemptions")
+        redemptions = history_r.json()
+
+        assert len(redemptions) == 3
+        # Verify sorted by timestamp desc (newest first)
+        timestamps = [r["timestamp"] for r in redemptions]
+        assert timestamps == sorted(timestamps, reverse=True)
+
 
 class TestChoresAPI:
     @pytest.mark.asyncio

--- a/frontend/src/__tests__/UserDetail.test.jsx
+++ b/frontend/src/__tests__/UserDetail.test.jsx
@@ -31,11 +31,27 @@ const USER_HISTORY = [
 const USER_STATS = {
   name: "Alice",
   total_points: 45,
+  points_redeemed: 10,
+  display_points: 35,
   points_7d: 15,
   points_30d: 45,
   completed_count: 9,
   skipped_count: 1,
 };
+
+const PEOPLE = [
+  { id: 1, name: "Alice", username: "alice" },
+];
+
+const REDEMPTIONS = [
+  {
+    id: 1,
+    person_id: 1,
+    amount: 10,
+    redeemed_by: "admin",
+    timestamp: "2026-04-20T10:00:00Z",
+  },
+];
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -56,6 +72,8 @@ describe("UserDetail", () => {
     vi.resetAllMocks();
     client.getLog.mockResolvedValue(USER_HISTORY);
     client.getUserStats.mockResolvedValue(USER_STATS);
+    client.getPeople.mockResolvedValue(PEOPLE);
+    client.getRedemptionHistory.mockResolvedValue(REDEMPTIONS);
   });
 
   it("renders user name", async () => {
@@ -85,7 +103,9 @@ describe("UserDetail", () => {
   it("displays user statistics", async () => {
     wrap(<UserDetail />);
     await waitFor(() => {
-      expect(screen.getByText(/Total Points/i)).toBeInTheDocument();
+      expect(screen.getByText(/Total Earned/i)).toBeInTheDocument();
+      expect(screen.getByText(/Redeemed/i)).toBeInTheDocument();
+      expect(screen.getByText(/Available/i)).toBeInTheDocument();
       expect(screen.getByText(/Last 7 Days/i)).toBeInTheDocument();
       expect(screen.getByText(/Last 30 Days/i)).toBeInTheDocument();
     });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -54,6 +54,7 @@ export const createPerson = (name, password, color) => {
 };
 export const updatePerson = (id, data) => request("PUT", `/people/${id}`, data);
 export const deletePerson = (id) => request("DELETE", `/people/${id}`);
+export const getRedemptionHistory = (personId) => request("GET", `/people/${personId}/redemptions`);
 
 // Points
 export const getLeaderboard = () => request("GET", "/points");

--- a/frontend/src/pages/UserDetail.css
+++ b/frontend/src/pages/UserDetail.css
@@ -112,6 +112,50 @@
   padding: 2rem;
 }
 
+.redemption-section {
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+}
+
+.redemption-section h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.2rem;
+  color: var(--text);
+}
+
+.redemption-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.redemption-entry {
+  display: grid;
+  grid-template-columns: 120px 1fr 120px;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.redemption-amount {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.redemption-redeemed-by {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.redemption-time {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: right;
+}
+
 .loading {
   text-align: center;
   padding: 2rem;
@@ -134,6 +178,15 @@
 
   .entry-action,
   .entry-time {
+    text-align: left;
+  }
+
+  .redemption-entry {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .redemption-time {
     text-align: left;
   }
 }

--- a/frontend/src/pages/UserDetail.jsx
+++ b/frontend/src/pages/UserDetail.jsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { getLog, getUserStats } from "../api/client";
+import { getLog, getUserStats, getPeople, getRedemptionHistory } from "../api/client";
 import "./UserDetail.css";
 
 const USER_ACTIVITY_ACTIONS = ["completed", "skipped", "reassigned"];
@@ -22,7 +22,23 @@ export default function UserDetail() {
     enabled: Boolean(userName),
   });
 
-  if (statsLoading || historyLoading) return <div className="loading">Loading…</div>;
+  const { data: people = [] } = useQuery({
+    queryKey: ["people"],
+    queryFn: getPeople,
+  });
+
+  const personId = useMemo(() => {
+    const person = people.find((p) => p.name === userName);
+    return person?.id;
+  }, [people, userName]);
+
+  const { data: redemptions = [], isLoading: redemptionsLoading } = useQuery({
+    queryKey: ["redemptions", personId],
+    queryFn: () => getRedemptionHistory(personId),
+    enabled: Boolean(personId),
+  });
+
+  if (statsLoading || historyLoading || redemptionsLoading) return <div className="loading">Loading…</div>;
 
   return (
     <div className="user-detail">
@@ -37,8 +53,18 @@ export default function UserDetail() {
       {stats && (
         <div className="stats-grid">
           <div className="stat-card">
-            <div className="stat-label">Total Points</div>
+            <div className="stat-label">Total Earned</div>
             <div className="stat-value">{stats.total_points}</div>
+          </div>
+
+          <div className="stat-card">
+            <div className="stat-label">Redeemed</div>
+            <div className="stat-value">{stats.points_redeemed ?? 0}</div>
+          </div>
+
+          <div className="stat-card">
+            <div className="stat-label">Available</div>
+            <div className="stat-value">{stats.display_points ?? stats.total_points}</div>
           </div>
 
           <div className="stat-card">
@@ -64,9 +90,9 @@ export default function UserDetail() {
       )}
 
       <div className="history-section">
-        <h2>History</h2>
+        <h2>Chore Activity</h2>
         {history.length === 0 ? (
-          <p className="empty-history">No history yet</p>
+          <p className="empty-history">No activity yet</p>
         ) : (
           <div className="history-list">
             {history.map((entry) => (
@@ -74,6 +100,25 @@ export default function UserDetail() {
                 <div className="entry-chore">{entry.chore_name}</div>
                 <div className="entry-action">{entry.action}</div>
                 <div className="entry-time">
+                  {new Date(entry.timestamp).toLocaleDateString()}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="redemption-section">
+        <h2>Redemption History</h2>
+        {redemptions.length === 0 ? (
+          <p className="empty-history">No redemptions yet</p>
+        ) : (
+          <div className="redemption-list">
+            {redemptions.map((entry) => (
+              <div key={entry.id} className="redemption-entry">
+                <div className="redemption-amount">{entry.amount} points</div>
+                <div className="redemption-redeemed-by">by {entry.redeemed_by}</div>
+                <div className="redemption-time">
                   {new Date(entry.timestamp).toLocaleDateString()}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Add GET /people/{person_id}/redemptions backend endpoint
- Display redemption history on UserDetail page
- Show earned/redeemed/available points breakdown
- Add redemption list with amount, redeemed_by, timestamp

## Test plan
- [x] All 43 backend tests pass
- [x] New endpoint returns redemption history sorted by timestamp
- [x] UserDetail page displays redemptions correctly
- [x] Responsive layout on mobile
- [x] Points breakdown accurate

Closes #94

🤖 Generated with Claude Code