### PR TITLE
fix: Initialize database sequences to prevent primary key constraint violations

### DIFF
--- a/backend/alembic/versions/9bbbe756fac7_initialize_sequences_for_auto_increment_.py
+++ b/backend/alembic/versions/9bbbe756fac7_initialize_sequences_for_auto_increment_.py
@@ -1,0 +1,68 @@
+"""Initialize sequences for auto-increment IDs
+
+Revision ID: 9bbbe756fac7
+Revises: 6809073594f7
+Create Date: 2026-05-05 22:16:21.124305
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9bbbe756fac7'
+down_revision = '6809073594f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # For each table with auto-increment ID, create sequence if needed and set nextval
+    tables = [
+        'people',
+        'token_blacklist',
+        'chores',
+        'points_log',
+        'redemption_log',
+        'chore_log',
+        'settings'
+    ]
+
+    for table in tables:
+        # Create sequence if it doesn't exist
+        op.execute(f"""
+            CREATE SEQUENCE IF NOT EXISTS {table}_id_seq;
+        """)
+
+        # Get max ID from table (handle empty tables)
+        op.execute(f"""
+            SELECT SETVAL('{table}_id_seq',
+                COALESCE((SELECT MAX(id) FROM {table}), 0) + 1
+            );
+        """)
+
+        # Bind sequence to column (idempotent, will fail silently if already bound)
+        op.execute(f"""
+            ALTER TABLE {table}
+            ALTER COLUMN id SET DEFAULT nextval('{table}_id_seq');
+        """)
+
+
+def downgrade() -> None:
+    # Drop sequences
+    tables = [
+        'people',
+        'token_blacklist',
+        'chores',
+        'points_log',
+        'redemption_log',
+        'chore_log',
+        'settings'
+    ]
+
+    for table in tables:
+        op.execute(f"DROP SEQUENCE IF EXISTS {table}_id_seq;")
+        op.execute(f"""
+            ALTER TABLE {table}
+            ALTER COLUMN id DROP DEFAULT;
+        """)


### PR DESCRIPTION
## Summary
Fix chore creation errors caused by auto-increment sequences not being properly initialized after database restarts. Adds Alembic migration to create sequences for all ID columns and set nextval to MAX(id) + 1.

## Changes
- Create Alembic migration to initialize sequences for all auto-increment ID columns
- Set sequence nextval to prevent duplicate key violations
- Bind sequences to column defaults
- Affects: people, token_blacklist, chores, points_log, redemption_log, chore_log, settings

## Test Plan
- [x] All 168 backend tests pass
- [x] Migration runs without errors
- [x] Sequences properly initialized and bound
- [x] No regressions in existing functionality

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)