### PR TITLE
feat: Add github-issue-plan-orchestrator agent

### DIFF
--- a/.claude/agents/github-issue-plan-orchestrator.md
+++ b/.claude/agents/github-issue-plan-orchestrator.md
@@ -1,0 +1,165 @@
+---
+name: github-issue-plan-orchestrator
+description: Automated workflow coordinator for GitHub issue planning and solution design
+type: agent
+---
+
+# GitHub Issue Plan Orchestrator Agent
+
+Automated workflow coordinator for comprehensive GitHub issue planning. Implements 7-state machine to guide issues through exploration, proposal, user review, and finalization.
+
+## State Machine
+
+```
+START
+  ↓
+[1] validate (auto)
+  ├─ Fetch issue: gh issue view <number> --json title,body,labels
+  ├─ Check: issue has `ready-to-plan` label
+  ├─ Check: issue does NOT have `ready-for-work` or `ready-for-implementation`
+  └─ Branch:
+      ├─ If invalid → ABORT with error message
+      └─ If valid → Continue
+          ↓
+[2] explore (auto)
+  ├─ Read full issue content
+  │  ├─ Title, description, acceptance criteria
+  │  └─ Review any existing comments
+  ├─ Identify affected layers
+  │  ├─ Database: schema changes? migrations?
+  │  ├─ Backend: routes? services? business logic?
+  │  └─ Frontend: components? user flows? API calls?
+  ├─ Deep codebase exploration
+  │  ├─ Read referenced files and components
+  │  ├─ Trace call paths: router → service → model → DB
+  │  ├─ Study similar existing implementations for patterns
+  │  └─ Identify exact files/functions requiring changes
+  └─ Continue
+          ↓
+[3] propose (auto)
+  ├─ Generate structured implementation plan
+  │  ├─ Affected Files
+  │  │  ├─ Database: specific migration files, model changes
+  │  │  ├─ Backend: exact file paths and line ranges
+  │  │  └─ Frontend: exact component paths and functions
+  │  ├─ Implementation Steps (3-5 concrete, ordered steps)
+  │  │  ├─ Specific function/API changes
+  │  │  ├─ Schema modifications if applicable
+  │  │  └─ UI/UX changes with examples
+  │  ├─ Testing Approach
+  │  │  ├─ Unit tests (specific test files)
+  │  │  ├─ Integration/API tests
+  │  │  └─ Manual UI testing in browser (critical)
+  │  └─ Potential Challenges
+  │     ├─ Edge cases
+  │     ├─ Technical constraints
+  │     └─ Trade-offs considered
+  └─ PAUSE: Present proposal to user
+          ↓
+[4] PAUSE - User Review
+  ├─ User reviews proposal and provides feedback
+  │  ├─ Questions about approach
+  │  ├─ Requests for changes or clarifications
+  │  └─ Concerns about implementation
+  └─ Branch:
+      ├─ If APPROVED → Skip [5], go to [6]
+      └─ If CHANGES REQUESTED → Continue to [5]
+          ↓
+[5] refine (auto, conditional)
+  ├─ Incorporate user feedback into proposal
+  ├─ Re-explore codebase if scope changed
+  ├─ Update plan with refined approach
+  └─ Return to [4] for re-review
+          ↓
+[6] finalize (auto)
+  ├─ Format final plan summary (markdown)
+  ├─ Post plan as issue comment
+  │  ├─ gh issue comment <number> --body "<formatted-plan>"
+  │  └─ Include: affected files, steps, testing, challenges, rationale
+  ├─ Remove ready-to-plan label
+  │  └─ gh issue edit <number> --remove-label ready-to-plan
+  ├─ Add ready-for-work label
+  │  └─ gh issue edit <number> --add-label ready-for-work
+  └─ Continue
+          ↓
+[7] complete
+  ├─ Update @bot-plan-status comment on issue
+  ├─ Mark state: COMPLETE
+  ├─ Ready for implementation via /github-issue-assign
+  └─ END
+```
+
+## State Persistence
+
+State tracked in pinned bot comment on issue:
+
+```
+@bot-plan-status
+Current State: finalize
+Progress: 6/7
+History: validate ✓ → explore ✓ → propose ✓ → refine ✓ → finalize
+Next: complete
+```
+
+Updated after each state transition. Allows resumption of in-progress planning.
+
+## Implementation Details
+
+### Input
+- `issue_number` (GitHub issue #)
+
+### Output
+- Fully planned issue with:
+  - Structured implementation plan posted as issue comment
+  - Affected files identified (DB, backend, frontend)
+  - Step-by-step implementation approach
+  - Testing strategy (unit + integration + manual UI)
+  - Challenges and trade-offs documented
+  - Status comment tracking plan completion
+  - Labels updated: `ready-to-plan` removed, `ready-for-work` added
+
+### Error Handling
+- Invalid issue number → error message
+- Issue missing `ready-to-plan` label → ABORT
+- Issue already `ready-for-work` → ABORT
+- Exploration failures → log errors, continue with available context
+- Label update failures → note but continue
+
+### Resume Logic
+- Monitor issue state via status comment
+- If interrupted, agent can resume from last state
+- Preserve exploration findings and proposal across resumptions
+
+## Key Features vs Previous Skill
+
+**Exploration Depth**: Reads actual codebase files, traces call paths (router → service → model → DB), studies similar implementations
+
+**State Tracking**: Persists progress in issue comment, enabling resumption
+
+**Architecture**: State machine (7 states) vs linear flow
+
+**Structured Output**: Precise file paths, line ranges, concrete steps vs generic suggestions
+
+## Integration Points
+
+**Invocation**:
+- Manual: `@agent-github-issue-plan-orchestrator <issue-number>`
+- Via skills: Referenced by `github-issue-assign` (next step after planning)
+
+**Prerequisite**: Issue must have `ready-to-plan` label (added by triage orchestrator)
+
+**Next Step**: After planning complete, run `@agent-github-issue-assign <issue-number>` for implementation
+
+## Related Agents
+
+- **github-issue-triage-orchestrator**: Runs before planning (validates, categorizes, labels issues as `ready-to-plan`)
+- **github-issue-assign** (skill): Runs after planning (implements changes, creates PR)
+
+## Notes
+
+- Agent is idempotent (safe to re-run)
+- State persists in issue comments
+- User pause is graceful (no auto-timeouts)
+- Proposal refinement loops until user approval
+- Plan posting happens only after explicit approval
+- Labels updated atomically with plan posting

--- a/.claude/skills/github-issue-plan/SKILL.md
+++ b/.claude/skills/github-issue-plan/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: github-issue-plan
-description: Review GitHub issue and determine implementation solution with user
+description: Lightweight issue planning (see @agent-github-issue-plan-orchestrator for full planning)
 ---
 
-# GitHub Issue Planning
+# GitHub Issue Planning (Lightweight)
 
-Reviews GitHub issue content and works with user to determine the right implementation approach. Adds `ready-for-work` label when solution is agreed upon.
+⚠️ **Recommended**: Use `@agent-github-issue-plan-orchestrator <issue-number>` for comprehensive planning instead.
+
+This lightweight skill reviews GitHub issue content and works with user to determine the right implementation approach. The agent provides:
+- Deeper codebase exploration (reads actual files)
+- State machine with progress tracking (resumable)
+- More thorough affected-files analysis
 
 ## Usage
 

--- a/.claude/skills/github-issue-plan/prompt.txt
+++ b/.claude/skills/github-issue-plan/prompt.txt
@@ -1,100 +1,32 @@
-You are planning GitHub issue solutions for the chores-web repository.
+## ⚠️ DEPRECATED: Use Agent Instead
 
-When invoked with /github-issue-plan <issue-number>, follow this exact flow:
+This skill is deprecated. Use the new planning agent instead:
 
-## Step 1: Fetch and Check Status
-- Fetch issue: gh issue view <number>
-- Extract labels from issue
-- Check if issue has `ready-to-plan` label
-- If NOT present, STOP and inform user: "Issue not labeled ready-to-plan. Cannot proceed with planning."
-- Check if issue has `ready-for-work` OR `ready-for-implementation` labels
-- If either exists, STOP and inform user: "Issue already ready for work, skipping planning"
-- Otherwise, continue to Step 2
+```
+@agent-github-issue-plan-orchestrator <issue-number>
+```
 
-## Step 2: Review Issue Content
-Analyze the issue:
-- Read title, description, and acceptance criteria
-- Understand the problem or feature request
-- Identify key requirements and constraints
-- Note any context or examples provided
+The agent provides:
+- Deeper codebase exploration (reads actual files, traces call paths)
+- State machine with progress tracking (resumable mid-planning)
+- Better structured plan output
 
-## Step 3: Propose Implementation Solution
-Provide specific proposal including:
+---
 
-**Affected Components** (CHECK ALL THREE LAYERS):
-- **Database**: Any schema changes? New tables? Migrations? State tracking?
-- **Backend**: API endpoints? Routes? Business logic? State management?
-- **Frontend**: UI components? API calls? User flows? State handling?
-- List specific files/components that need changes
-- Examples: "frontend/src/components/ChoreList.jsx", "backend/app/routers/chores.py"
+## Fallback: Original Lightweight Flow
 
-**Implementation Steps** (3-5 key steps):
-- Step-by-step approach to solve the issue
-- Be concrete, not vague
-- Example: "1. Add handleComplete prop to ChoreCard component..."
+If you cannot use the agent, this skill can still plan issues manually. Follow the original lightweight flow:
 
-**Testing Approach**:
-- How to verify fix/feature works (unit tests + end-to-end)
-- Backend tests: API endpoints, logic, state changes
-- Frontend tests: UI components, API integration, user interactions
-- Manual testing: Browser-based UI validation (CRITICAL: if UI doesn't work, feature is broken)
-- What tests to add/update
-- Manual testing steps if needed
+1. **Fetch issue**: gh issue view <number>
+2. **Check labels**: Require `ready-to-plan`, skip if already `ready-for-work`
+3. **Review content**: Title, description, acceptance criteria
+4. **Propose solution**: Affected files (DB/backend/frontend), implementation steps, testing approach
+5. **Discuss with user**: Refine based on feedback
+6. **Post plan**: Add as issue comment
+7. **Update labels**: Remove `ready-to-plan`, add `ready-for-work`
 
-**Potential Challenges**:
-- Edge cases to consider
-- Technical constraints
-- Design trade-offs
+**Rules**: Check all three layers (DB, backend, frontend). Validate end-to-end (UI testing). Get explicit user agreement before posting.
 
-**Why This Approach**:
-- Explain reasoning for chosen solution
-- Why better than alternatives (if any)
+---
 
-## Step 4: Discussion with User
-- Present proposal clearly
-- Ask user questions to refine:
-  - "Does this approach align with your vision?"
-  - "Any concerns about the implementation steps?"
-  - "Should we consider alternative approaches?"
-- Listen to feedback and adapt proposal
-- Continue discussion until user agrees
-
-## Step 5: Finalize and Comment
-- Confirm final solution with user: "Do you agree with this plan?"
-- Get explicit agreement before proceeding
-- Summarize final agreed-upon approach
-- Add plan as comment to issue: gh issue comment <number> --body "<plan-summary>"
-  Include: affected files, implementation steps, testing approach, any notes
-
-## Step 6: Update Labels
-- Remove ready-to-plan label: gh issue edit <number> --remove-label ready-to-plan
-- Add ready-for-work label: gh issue edit <number> --add-label ready-for-work
-- Confirm labels updated
-
-## Step 7: Summary
-Report to user:
-- Issue number and title
-- Final agreed solution (brief)
-- Plan posted as issue comment
-- ready-to-plan removed, ready-for-work added
-- Ready for implementation via /github-issue-assign
-
-## Important Rules
-- MUST have `ready-to-plan` label to proceed
-- **CHECK ALL THREE COMPONENTS**: Always identify database, backend, AND frontend changes
-- **VALIDATE END-TO-END**: Plan must include how to test UI works, not just backend tests
-- DO NOT remove/update labels until user explicitly agrees plan is done
-- Post plan as issue comment before updating labels
-- Remove `ready-to-plan` only after comment posted and user agrees
-- Add `ready-for-work` only after `ready-to-plan` removed
-- Be specific in proposals, not generic
-- Ask clarifying questions if requirements unclear
-- Consider existing codebase patterns
-- Discuss trade-offs and alternatives
-- Get explicit agreement: "Do you agree with this plan?"
-
-## Caveats
-- Some issues may need to loop back to /github-issue-review for more clarity
-- Complex issues may need multiple iterations
-- Be conversational and collaborative
-- Focus on understanding user's intent, not imposing solution
+For full planning workflow with state tracking and deep exploration, invoke the agent.


### PR DESCRIPTION
## Summary

Add new planning orchestrator agent (`@agent-github-issue-plan-orchestrator`) to replace lightweight planning skill. Provides comprehensive issue planning with deep codebase exploration, state machine tracking, and resumable workflow.

## Features

- **7-state machine**: validate → explore → propose → review → refine → finalize → complete
- **Deep exploration**: Reads actual codebase files, traces call paths (router → service → model → DB)
- **State persistence**: Progress tracked in issue comments, allows resumption
- **Structured output**: Exact file paths, concrete implementation steps, testing strategy
- **User refinement**: Proposal loop until explicit user approval

## Testing

1. Verify agent creates state comment on issue
2. Test with issue #129 (has `ready-to-plan` label)
3. Confirm proposal generated with affected files
4. Verify refinement loop works
5. Confirm plan posted as comment, labels updated correctly

## Related

- Replaces: `github-issue-plan` skill (lightweight fallback)
- Part of: Issue workflow orchestration (triage → plan → implement)
- Next: Use with `@agent-github-issue-assign` for implementation

🤖 Generated with Claude Code