### PR TITLE
Fix: Add missing permissions for Docker push to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
Adds `packages`, `attestations`, and `id-token` permissions to the release workflow required by docker/build-push-action when pushing to ghcr.io.

Fixes #136

## Testing
Trigger release workflow when merged to verify Docker images push successfully to ghcr.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)