### PR TITLE
Fix: Correct gh-pages deployment to handle history conflicts

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,8 +31,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f site/
+          git fetch origin gh-pages --depth=1 2>/dev/null || true
+          git checkout -b gh-pages origin/gh-pages 2>/dev/null || git checkout --orphan gh-pages
+          git rm -rf . || true
+          cp -r ../site/* .
+          git add .
           git commit -m "docs: Publish documentation" || true
-          git subtree push --prefix site origin gh-pages
+          git push -f origin gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes docs deployment workflow failure caused by `git subtree push` conflicts.

## Problem
Previous approach used `git subtree push` which fails when gh-pages branch has mismatched history from previous deployments.

## Solution
Explicit checkout and push workflow:
1. Fetch gh-pages (or create orphan if missing)
2. Clear all files
3. Copy built site/ contents
4. Force push to gh-pages

This handles history conflicts and ensures clean deployments.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)