### PR TITLE
fix: Log actual user instead of system when skipping chores (#154)

### DIFF
--- a/backend/app/routers/chores.py
+++ b/backend/app/routers/chores.py
@@ -341,14 +341,14 @@ async def action_complete(chore_id: int, body: CompleteBody, current_user: str =
 @router.post("/{chore_id}/skip", response_model=ChoreOut)
 async def action_skip(chore_id: int, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     chore = await _get_or_404(chore_id, db)
-    return _enrich(await skip_chore(chore, db))
+    return _enrich(await skip_chore(chore, db, skipped_by=current_user))
 
 
 @router.post("/{chore_id}/skip-reassign", response_model=ChoreOut)
 async def action_skip_reassign(chore_id: int, body: SkipReassignBody, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     await _validate_people_exist(db, None, body.assignee)
     chore = await _get_or_404(chore_id, db)
-    return _enrich(await skip_and_reassign_chore(chore, db, assignee=body.assignee))
+    return _enrich(await skip_and_reassign_chore(chore, db, assignee=body.assignee, skipped_by=current_user))
 
 
 @router.post("/{chore_id}/reassign", response_model=ChoreOut)

--- a/backend/app/services/chore_service.py
+++ b/backend/app/services/chore_service.py
@@ -255,14 +255,14 @@ async def complete_chore(
     return chore
 
 
-async def skip_chore(chore: Chore, db: AsyncSession) -> Chore:
+async def skip_chore(chore: Chore, db: AsyncSession, skipped_by: Optional[str] = None) -> Chore:
     chore.next_due = _calc_next_due(chore)
     chore.state = "complete"
     chore.last_changed_at = _now()
     chore.last_changed_by = None
     chore.last_change_type = CHANGE_SKIPPED
 
-    await _log_action(chore, CHANGE_SKIPPED, "system", db)
+    await _log_action(chore, CHANGE_SKIPPED, skipped_by or "system", db)
 
     db.add(chore)
     await db.commit()
@@ -274,8 +274,9 @@ async def skip_and_reassign_chore(
     chore: Chore,
     db: AsyncSession,
     assignee: Optional[str] = None,
+    skipped_by: Optional[str] = None,
 ) -> Chore:
-    chore = await skip_chore(chore, db)
+    chore = await skip_chore(chore, db, skipped_by=skipped_by)
 
     if assignee:
         chore.current_assignee = assignee

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -496,6 +496,15 @@ class TestChoresAPI:
         assert r.json()["state"] == "complete"
         assert r.json()["last_change_type"] == "skipped"
 
+        # Verify ChoreLog has correct person (not "system")
+        r = await authenticated_client.get(f"/log?chore_id={chore_id}&action=skipped")
+        assert r.status_code == 200
+        logs = r.json()
+        assert len(logs) > 0
+        log_entry = logs[0]
+        assert log_entry["person"] == "testuser"
+        assert log_entry["action"] == "skipped"
+
     @pytest.mark.asyncio
     async def test_reassign_action(self, authenticated_client):
         await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
@@ -550,6 +559,15 @@ class TestChoresAPI:
         data = r.json()
         assert data["state"] == "complete"
         assert data["current_assignee"] == "Bob"
+
+        # Verify ChoreLog has correct person for skip action (not "system")
+        r = await authenticated_client.get(f"/log?chore_id={chore_id}&action=skipped")
+        assert r.status_code == 200
+        logs = r.json()
+        assert len(logs) > 0
+        skip_log = logs[0]
+        assert skip_log["person"] == "testuser"
+        assert skip_log["action"] == "skipped"
 
     @pytest.mark.asyncio
     async def test_reject_invalid_eligible_people(self, authenticated_client):


### PR DESCRIPTION
## Summary

Fix skip_chore() and skip_and_reassign_chore() functions to log the actual user who performed the skip operation instead of hardcoding "system" in the audit log. This ensures the ChoreLog accurately tracks who skipped a chore for proper audit trail accuracy.

## Changes

**Backend: chore_service.py**
- Add `skipped_by: Optional[str] = None` parameter to `skip_chore()` function (line 258)
- Update `_log_action` call to use `skipped_by or "system"` to allow override
- Add `skipped_by: Optional[str] = None` parameter to `skip_and_reassign_chore()` function (line 273)
- Pass `skipped_by` when calling `skip_chore()` from `skip_and_reassign_chore()`

**Backend: chores.py router**
- Modify `action_skip` endpoint to pass `current_user` to `skip_chore()`
- Modify `action_skip_reassign` endpoint to pass `current_user` to `skip_and_reassign_chore()`

**Testing: test_api.py**
- Enhanced `test_skip_action` to verify ChoreLog records the correct person (testuser, not "system")
- Enhanced `test_skip_reassign_action` similarly to verify audit trail accuracy

## Test Results

All 47 tests pass, including:
- test_skip_action with verification of ChoreLog person field
- test_skip_reassign_action with verification of ChoreLog person field
- All existing tests continue to pass

## Backward Compatibility

- Full backward compatibility maintained
- All parameters are optional with sensible defaults
- Existing code that calls `skip_chore()` without the new parameter continues to work as before

Closes #154

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>