### PR TITLE
fix: Standardize actor logging to use usernames and distinguish schedule from system (#135)

### DIFF
--- a/backend/app/routers/chores.py
+++ b/backend/app/routers/chores.py
@@ -335,7 +335,7 @@ async def delete_chore(chore_id: int, current_user: str = Depends(get_current_us
 @router.post("/{chore_id}/complete", response_model=ChoreOut)
 async def action_complete(chore_id: int, body: CompleteBody, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     chore = await _get_or_404(chore_id, db)
-    return _enrich(await complete_chore(chore, db, completed_by=body.completed_by))
+    return _enrich(await complete_chore(chore, db, completed_by=current_user))
 
 
 @router.post("/{chore_id}/skip", response_model=ChoreOut)
@@ -362,4 +362,4 @@ async def action_reassign(chore_id: int, body: ReassignBody, current_user: str =
 async def action_mark_due(chore_id: int, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     chore = await _get_or_404(chore_id, db)
     timezone = await _get_timezone(db)
-    return _enrich(await mark_due_chore(chore, db, timezone=timezone))
+    return _enrich(await mark_due_chore(chore, db, marked_by=current_user, timezone=timezone))

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -99,7 +99,7 @@ async def redeem_points(person_id: int, body: PersonRedemption, current_user: st
         raise HTTPException(status_code=400, detail="Redemption amount must be positive")
 
     # Calculate total points from PointsLog (same as stats endpoint)
-    points_result = await db.execute(select(PointsLog).where(PointsLog.person == person.name))
+    points_result = await db.execute(select(PointsLog).where(PointsLog.person == person.username))
     logs = points_result.scalars().all()
     total_points = sum(log.points for log in logs)
 

--- a/backend/app/routers/points.py
+++ b/backend/app/routers/points.py
@@ -29,7 +29,7 @@ async def points_summary(current_user: str = Depends(get_current_user), db: Asyn
     cutoff_7d = now - timedelta(days=7)
     cutoff_30d = now - timedelta(days=30)
 
-    people_result = await db.execute(select(Person.name).order_by(Person.name))
+    people_result = await db.execute(select(Person.username).order_by(Person.username))
     people = [row[0] for row in people_result]
 
     log_result = await db.execute(
@@ -78,14 +78,15 @@ async def user_stats(person: str, current_user: str = Depends(get_current_user),
     skipped_count = sum(1 for log in chore_logs if log.action == "skipped")
 
     person_result = await db.execute(
-        select(Person).where(Person.name == person)
+        select(Person).where(Person.username == person)
     )
     person_obj = person_result.scalar_one_or_none()
     points_redeemed = person_obj.points_redeemed if person_obj else 0
     display_points = total_points - points_redeemed
+    display_name = person_obj.name if person_obj else person
 
     return UserStatsOut(
-        name=person,
+        name=display_name,
         total_points=total_points,
         display_points=display_points,
         points_7d=points_7d,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -135,7 +135,7 @@ class ChoreOut(BaseModel):
 # ── Actions ───────────────────────────────────────────────────────────────────
 
 class CompleteBody(BaseModel):
-    completed_by: Optional[str] = None
+    pass
 
 
 class SkipReassignBody(BaseModel):

--- a/backend/app/services/chore_service.py
+++ b/backend/app/services/chore_service.py
@@ -228,8 +228,8 @@ async def complete_chore(
         )
         db.add(log)
 
-        # Update person's total points
-        person_result = await db.execute(select(Person).where(Person.name == completed_by))
+        # Update person's total points by username
+        person_result = await db.execute(select(Person).where(Person.username == completed_by))
         person = person_result.scalar_one_or_none()
         if person:
             person.points += chore.points
@@ -308,7 +308,7 @@ async def reassign_chore(chore: Chore, db: AsyncSession, assignee: str) -> Chore
     return chore
 
 
-async def mark_due_chore(chore: Chore, db: AsyncSession, timezone: str = None) -> Chore:
+async def mark_due_chore(chore: Chore, db: AsyncSession, marked_by: Optional[str] = None, timezone: str = None) -> Chore:
     # If timezone not provided, use system local date (for backward compatibility with tests)
     today = get_today(timezone) if timezone else date.today()
     if chore.state == "due" and chore.next_due == today:
@@ -316,10 +316,10 @@ async def mark_due_chore(chore: Chore, db: AsyncSession, timezone: str = None) -
     chore.state = "due"
     chore.next_due = today
     chore.last_changed_at = _now()
-    chore.last_changed_by = None
+    chore.last_changed_by = marked_by
     chore.last_change_type = CHANGE_MARKED_DUE
 
-    await _log_action(chore, CHANGE_MARKED_DUE, "system", db)
+    await _log_action(chore, CHANGE_MARKED_DUE, marked_by or "system", db)
 
     db.add(chore)
     await db.commit()
@@ -338,7 +338,7 @@ async def transition_overdue_chores(db: AsyncSession) -> int:
         chore.state = "due"
         chore.last_changed_at = _now()
         chore.last_change_type = CHANGE_FORCED_DUE
-        await _log_action(chore, "marked_due_by_schedule", "system", db)
+        await _log_action(chore, CHANGE_MARKED_DUE, "schedule", db)
         db.add(chore)
     if chores:
         await db.commit()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -97,9 +97,6 @@ class TestPeopleAPI:
 
     @pytest.mark.asyncio
     async def test_points_auto_update_on_chore_completion(self, authenticated_client):
-        person_r = await authenticated_client.post("/people", json={"name": "Helen", "username": "helen"})
-        person_id = person_r.json()["id"]
-
         chore_r = await authenticated_client.post("/chores", json={
             "name": "Test Chore",
             "schedule_type": "interval",
@@ -108,13 +105,14 @@ class TestPeopleAPI:
         })
         chore_id = chore_r.json()["id"]
 
-        # Complete chore
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Helen"})
+        # Complete chore (points credited to authenticated user: testuser)
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
 
-        # Check person points updated
+        # Check testuser points updated
         people_r = await authenticated_client.get(f"/people")
-        person = next(p for p in people_r.json() if p["id"] == person_id)
-        assert person["points"] == 25
+        testuser = next((p for p in people_r.json() if p["username"] == "testuser"), None)
+        assert testuser is not None
+        assert testuser["points"] == 25
 
     @pytest.mark.asyncio
     async def test_points_cannot_be_manually_set(self, authenticated_client):
@@ -129,9 +127,6 @@ class TestPeopleAPI:
 
     @pytest.mark.asyncio
     async def test_multiple_completions_accumulate_points(self, authenticated_client):
-        create_r = await authenticated_client.post("/people", json={"name": "Jack", "username": "jack"})
-        person_id = create_r.json()["id"]
-
         chore_r = await authenticated_client.post("/chores", json={
             "name": "Test Chore",
             "schedule_type": "interval",
@@ -140,14 +135,15 @@ class TestPeopleAPI:
         })
         chore_id = chore_r.json()["id"]
 
-        # Complete twice
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Jack"})
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Jack"})
+        # Complete twice (points credited to authenticated user: testuser)
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
 
-        # Check total points
+        # Check total points for testuser
         people_r = await authenticated_client.get(f"/people")
-        person = next(p for p in people_r.json() if p["id"] == person_id)
-        assert person["points"] == 60
+        testuser = next((p for p in people_r.json() if p["username"] == "testuser"), None)
+        assert testuser is not None
+        assert testuser["points"] == 60
 
     @pytest.mark.asyncio
     async def test_redemption_history_empty(self, authenticated_client):
@@ -165,9 +161,6 @@ class TestPeopleAPI:
 
     @pytest.mark.asyncio
     async def test_redemption_history_after_redemption(self, authenticated_client):
-        person_r = await authenticated_client.post("/people", json={"name": "Laura", "username": "laura"})
-        person_id = person_r.json()["id"]
-
         # Create and complete chore to earn points
         chore_r = await authenticated_client.post("/chores", json={
             "name": "Test",
@@ -176,7 +169,13 @@ class TestPeopleAPI:
             "points": 50
         })
         chore_id = chore_r.json()["id"]
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Laura"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+
+        # Get testuser ID
+        people_r = await authenticated_client.get("/people")
+        testuser = next((p for p in people_r.json() if p["username"] == "testuser"), None)
+        assert testuser is not None
+        person_id = testuser["id"]
 
         # Redeem points
         redeem_r = await authenticated_client.post(
@@ -197,9 +196,6 @@ class TestPeopleAPI:
 
     @pytest.mark.asyncio
     async def test_redemption_history_sorted_by_timestamp(self, authenticated_client):
-        person_r = await authenticated_client.post("/people", json={"name": "Mike", "username": "mike"})
-        person_id = person_r.json()["id"]
-
         # Create and complete chore to earn points
         chore_r = await authenticated_client.post("/chores", json={
             "name": "Test",
@@ -208,7 +204,13 @@ class TestPeopleAPI:
             "points": 100
         })
         chore_id = chore_r.json()["id"]
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Mike"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+
+        # Get testuser ID
+        people_r = await authenticated_client.get("/people")
+        testuser = next((p for p in people_r.json() if p["username"] == "testuser"), None)
+        assert testuser is not None
+        person_id = testuser["id"]
 
         # Multiple redemptions
         await authenticated_client.post(f"/people/{person_id}/redeem", json={"amount": 10})
@@ -480,10 +482,10 @@ class TestChoresAPI:
 
         # Force to due so we can complete it
         await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        r = await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        r = await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
         assert r.status_code == 200
         assert r.json()["state"] == "complete"
-        assert r.json()["last_completed_by"] == "Alice"
+        assert r.json()["last_completed_by"] == "testuser"
 
     @pytest.mark.asyncio
     async def test_skip_action(self, authenticated_client):
@@ -608,13 +610,13 @@ class TestPointsAPI:
         r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
         chore_id = r.json()["id"]
         await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
 
         r = await authenticated_client.get("/points")
         assert r.status_code == 200
         data = r.json()
         assert len(data) == 1
-        assert data[0]["person"] == "Alice"
+        assert data[0]["person"] == "testuser"
         assert data[0]["total_points"] == 5
 
     @pytest.mark.asyncio
@@ -622,9 +624,9 @@ class TestPointsAPI:
         r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
         chore_id = r.json()["id"]
         await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
 
-        r = await authenticated_client.get("/points/Alice")
+        r = await authenticated_client.get("/points/testuser")
         assert r.status_code == 200
         data = r.json()
         assert len(data) == 1
@@ -634,10 +636,10 @@ class TestPointsAPI:
     async def test_points_summary_empty(self, authenticated_client):
         r = await authenticated_client.get("/points/summary")
         assert r.status_code == 200
-        # TestUser created by authenticated_client fixture
+        # testuser created by authenticated_client fixture
         summary = r.json()
         assert len(summary) == 1
-        assert summary[0]["person"] == "TestUser"
+        assert summary[0]["person"] == "testuser"
         assert summary[0]["points_7d"] == 0
         assert summary[0]["points_30d"] == 0
 
@@ -648,8 +650,9 @@ class TestPointsAPI:
         r = await authenticated_client.get("/points/summary")
         assert r.status_code == 200
         names = [e["person"] for e in r.json()]
-        assert "Alice" in names
-        assert "Bob" in names
+        assert "alice" in names
+        assert "bob" in names
+        assert "testuser" in names
 
     @pytest.mark.asyncio
     async def test_points_summary_counts_recent(self, authenticated_client):
@@ -657,18 +660,18 @@ class TestPointsAPI:
         r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
         chore_id = r.json()["id"]
         await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
 
         r = await authenticated_client.get("/points/summary")
-        alice = next(e for e in r.json() if e["person"] == "Alice")
-        assert alice["points_7d"] == 5
-        assert alice["points_30d"] == 5
+        testuser = next(e for e in r.json() if e["person"] == "testuser")
+        assert testuser["points_7d"] == 5
+        assert testuser["points_30d"] == 5
 
     @pytest.mark.asyncio
     async def test_points_summary_zero_for_no_activity(self, authenticated_client):
         await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
         r = await authenticated_client.get("/points/summary")
-        bob = next(e for e in r.json() if e["person"] == "Bob")
+        bob = next(e for e in r.json() if e["person"] == "bob")
         assert bob["points_7d"] == 0
         assert bob["points_30d"] == 0
 
@@ -688,11 +691,11 @@ class TestLogAPI:
         chore_id = r.json()["id"]
 
         await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "Alice"})
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
         await authenticated_client.post(f"/chores/{chore_id}/reassign", json={"assignee": "Bob"})
         await authenticated_client.put(f"/chores/{chore_id}", json={"points": 9})
 
-        r = await authenticated_client.get("/log?person=Alice&actions=completed&actions=reassigned")
+        r = await authenticated_client.get("/log?person=testuser&actions=completed&actions=reassigned")
         assert r.status_code == 200
         actions = [entry["action"] for entry in r.json()]
         assert "completed" in actions

--- a/frontend/src/__tests__/client.test.js
+++ b/frontend/src/__tests__/client.test.js
@@ -38,15 +38,15 @@ describe("API client", () => {
     );
   });
 
-  it("completeChore calls POST /chores/:id/complete with body", async () => {
+  it("completeChore calls POST /chores/:id/complete", async () => {
     mockOk({ state: "complete" });
     const { completeChore } = await import("../api/client");
-    await completeChore("vacuum", "Alice");
+    await completeChore("vacuum");
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/chores/vacuum/complete"),
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ completed_by: "Alice" }),
+        body: JSON.stringify({}),
       })
     );
   });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -37,8 +37,8 @@ export const createChore = (data) => request("POST", "/chores", data);
 export const updateChore = (id, data) => request("PUT", `/chores/${id}`, data);
 export const deleteChore = (id) => request("DELETE", `/chores/${id}`);
 
-export const completeChore = (id, completedBy) =>
-  request("POST", `/chores/${id}/complete`, { completed_by: completedBy ?? null });
+export const completeChore = (id) =>
+  request("POST", `/chores/${id}/complete`, {});
 export const skipChore = (id) => request("POST", `/chores/${id}/skip`);
 export const skipReassignChore = (id, assignee) =>
   request("POST", `/chores/${id}/skip-reassign`, { assignee: assignee ?? null });

--- a/frontend/src/components/Log.jsx
+++ b/frontend/src/components/Log.jsx
@@ -5,7 +5,7 @@ import { MdFilterList } from "react-icons/md";
 import { getLog, getPeople, getChores } from "../api/client";
 import "./Log.css";
 
-const ACTIONS = ["completed", "skipped", "reassigned", "created", "deleted", "updated"];
+const ACTIONS = ["completed", "skipped", "reassigned", "created", "deleted", "updated", "marked_due"];
 
 const PAGE_SIZE = 20;
 
@@ -120,6 +120,7 @@ export default function Log() {
           >
             <option value="">All people</option>
             <option value="system">System</option>
+            <option value="schedule">Schedule</option>
             {people.map((p) => (
               <option key={p.id} value={p.name}>
                 {p.name}

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -80,7 +80,6 @@ export default function Manage() {
 
   const [modal, setModal] = useState(null); // null | { mode: "create" } | { mode: "edit", chore }
   const [deleteTarget, setDeleteTarget] = useState(null); // chore to confirm-delete
-  const [completeTarget, setCompleteTarget] = useState(null); // chore waiting for completion user selection
   const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   const filters = useMemo(() => getFiltersFromSearchParams(searchParams), [searchParams]);
@@ -114,7 +113,7 @@ export default function Manage() {
   });
 
   const completeMut = useMutation({
-    mutationFn: ({ id, completedBy }) => completeChore(id, completedBy),
+    mutationFn: (id) => completeChore(id),
     onSuccess: () => { invalidate(); setCompleteTarget(null); },
   });
 
@@ -353,12 +352,7 @@ export default function Manage() {
             onEdit={(chore) => setModal({ mode: "edit", chore })}
             onDelete={(chore) => setDeleteTarget(chore)}
             onComplete={(chore) => {
-              const assignee = chore.assignment_type === "fixed" ? chore.assignee : chore.current_assignee;
-              if (assignee) {
-                completeMut.mutate({ id: chore.id, completedBy: assignee });
-              } else {
-                setCompleteTarget(chore);
-              }
+              completeMut.mutate(chore.id);
             }}
             onSkip={(chore) => skipMut.mutate(chore.id)}
             onMarkDue={(chore) => markDueMut.mutate(chore.id)}
@@ -412,42 +406,6 @@ export default function Manage() {
         </Modal>
       )}
 
-      {/* Complete chore modal (for unassigned chores) */}
-      {completeTarget && (
-        <Modal title={`Who completed ${completeTarget.name}?`} onClose={() => setCompleteTarget(null)}>
-          <div className="complete-form">
-            <div className="form-group">
-              <label htmlFor="complete-by">Person</label>
-              <select id="complete-by" defaultValue="">
-                <option value="">Select someone</option>
-                {people.map((person) => (
-                  <option key={person.id} value={person.name}>
-                    {person.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="confirm-actions">
-              <button className="btn-secondary" onClick={() => setCompleteTarget(null)}>
-                Cancel
-              </button>
-              <button
-                className="btn-primary"
-                disabled={completeMut.isPending}
-                onClick={() => {
-                  const select = document.getElementById("complete-by");
-                  const person = select.value;
-                  if (person) {
-                    completeMut.mutate({ id: completeTarget.id, completedBy: person });
-                  }
-                }}
-              >
-                {completeMut.isPending ? "Completing…" : "Complete"}
-              </button>
-            </div>
-          </div>
-        </Modal>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Consolidates inconsistent actor values in the chore log by standardizing to use usernames for user actions and distinguishing "schedule" from "system" for automated transitions.

**Before:**
- User actions logged display names ("Derek") instead of usernames ("derek")
- Schedule-triggered transitions logged as "system" instead of "schedule"
- Actor determined from request body instead of JWT token

**After:**
- User actions consistently use usernames
- Schedule-triggered transitions use "schedule" actor
- Actor determined from authenticated JWT token (current_user)

## Changes

### Backend
- **schemas.py**: Remove `completed_by` from `CompleteBody` schema (actor from JWT)
- **chore_service.py**:
  - `complete_chore()` accepts `completed_by` as username
  - `mark_due_chore()` accepts `marked_by` parameter  
  - `transition_overdue_chores()` uses "schedule" actor for log entries
- **chores.py router**: 
  - `/complete` passes `current_user` (username) to `complete_chore()`
  - `/mark-due` passes `current_user` to `mark_due_chore()`
- **people.py router**: Updated points redemption to lookup by username
- **points.py router**: Updated leaderboard and stats to use username lookups

### Frontend
- **Chores.jsx**: Removed `completed_by` from request, removed per-chore person selection modal
- **client.js**: Removed `completedBy` parameter from `completeChore()`
- **Log.jsx**: Added "marked_due" and "schedule" to action/person filter options

### Testing
- Updated test suite to work with username-based actors
- All tests pass with standardized username logging

## Closes
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)