### PR TITLE
fix: Keep points and due grids at 2 columns on mobile (#184)

### DIFF
--- a/frontend/src/components/UserCard.css
+++ b/frontend/src/components/UserCard.css
@@ -171,13 +171,3 @@
 .uc-workload-count:hover {
   opacity: 0.8;
 }
-
-@media (max-width: 640px) {
-  .uc-points-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .uc-due-grid {
-    grid-template-columns: 1fr;
-  }
-}


### PR DESCRIPTION
## Summary

- Removes the `@media (max-width: 640px)` block from `UserCard.css` that was collapsing `.uc-points-grid` and `.uc-due-grid` to a single column
- The 640px breakpoint was inconsistent with the app's standard 768px mobile breakpoint used for navigation
- Points (Last 7 Days / Last 30 Days) and Due (Due Now / Due Soon) grids now maintain their 2-column layout at all screen sizes

## Changes

- `frontend/src/components/UserCard.css`: removed 10-line media query block (lines 175-183)

## Test plan

- [ ] Open Dashboard on a mobile device or browser DevTools at <640px width
- [ ] Verify Points section shows 2 columns (Last 7 Days | Last 30 Days)
- [ ] Verify Due section shows 2 columns (Due Now | Due Soon)
- [ ] Verify user cards remain 1 per row on mobile
- [ ] Verify no horizontal scrolling on narrow viewports

## Related

Closes #184

Generated with [Claude Code](https://claude.com/claude-code)