### PR TITLE
fix: Populate settings values on Admin Panel load (#177)

### DIFF
--- a/frontend/src/__tests__/AdminPanel.test.jsx
+++ b/frontend/src/__tests__/AdminPanel.test.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import AdminPanel from "../pages/AdminPanel";
+import * as client from "../api/client";
+
+vi.mock("../api/client");
+vi.mock("../contexts/AuthContext", () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => ({ user: { username: "admin", is_admin: true }, logout: vi.fn() }),
+}));
+
+function wrap(ui) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("AdminPanel", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    client.getLogRetention.mockResolvedValue({ retention_days: 90 });
+    client.getConfig.mockResolvedValue({
+      due_soon_days: 3,
+      update_check_enabled: false,
+      update_check_interval: 12,
+    });
+    client.getUpdateCheckStatus.mockResolvedValue({
+      current_version: "1.0.0",
+      latest_version: "1.0.0",
+      update_available: false,
+      last_checked_at: null,
+    });
+  });
+
+  it("pre-populates the log retention input with the value from the API response", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/keep logs for/i);
+      expect(input.value).toBe("90");
+    });
+  });
+
+  it("does not leave the log retention input empty after data loads", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/keep logs for/i);
+      expect(input.value).not.toBe("");
+    });
+  });
+
+  it("pre-populates the due soon threshold input with the value from the API response", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/notify when due in/i);
+      expect(input.value).toBe("3");
+    });
+  });
+
+  it("does not leave the due soon threshold input empty after data loads", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/notify when due in/i);
+      expect(input.value).not.toBe("");
+    });
+  });
+
+  it("pre-populates update check enabled checkbox from the API response", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const checkbox = screen.getByLabelText(/enable update checking/i);
+      expect(checkbox.checked).toBe(false);
+    });
+  });
+
+  it("pre-populates update check interval input from the API response", async () => {
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/check interval/i);
+      expect(input.value).toBe("12");
+    });
+  });
+
+  it("reflects different API values when retention_days changes", async () => {
+    client.getLogRetention.mockResolvedValue({ retention_days: 30 });
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/keep logs for/i);
+      expect(input.value).toBe("30");
+    });
+  });
+
+  it("reflects different API values when config changes", async () => {
+    client.getConfig.mockResolvedValue({
+      due_soon_days: 7,
+      update_check_enabled: true,
+      update_check_interval: 48,
+    });
+    wrap(<AdminPanel />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/notify when due in/i).value).toBe("7");
+      expect(screen.getByLabelText(/enable update checking/i).checked).toBe(true);
+      expect(screen.getByLabelText(/check interval/i).value).toBe("48");
+    });
+  });
+});

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation } from "@tanstack/react-query";
@@ -26,20 +26,26 @@ export default function AdminPanel() {
   const { data: retentionData, isLoading: retentionLoading } = useQuery({
     queryKey: ["log-retention"],
     queryFn: getLogRetention,
-    onSuccess: (data) => {
-      setRetentionInput(String(data.retention_days));
-    },
   });
+
+  useEffect(() => {
+    if (retentionData?.retention_days !== undefined) {
+      setRetentionInput(String(retentionData.retention_days));
+    }
+  }, [retentionData]);
 
   const { data: configData, isLoading: configLoading } = useQuery({
     queryKey: ["config"],
     queryFn: getConfig,
-    onSuccess: (data) => {
-      setDueSoonDaysInput(String(data.due_soon_days));
-      setUpdateCheckEnabledInput(data.update_check_enabled);
-      setUpdateCheckIntervalInput(data.update_check_interval);
-    },
   });
+
+  useEffect(() => {
+    if (configData) {
+      setDueSoonDaysInput(String(configData.due_soon_days));
+      setUpdateCheckEnabledInput(configData.update_check_enabled);
+      setUpdateCheckIntervalInput(configData.update_check_interval);
+    }
+  }, [configData]);
 
   const { data: updateCheckStatus, isLoading: updateCheckLoading, refetch: refetchUpdateCheck } = useQuery({
     queryKey: ["update-check-status"],


### PR DESCRIPTION
## Summary

- Replaces removed TanStack Query v5 `onSuccess` callbacks on `useQuery` hooks with `useEffect` hooks in `AdminPanel.jsx`
- Settings fields (retention days, due soon days, update check settings) are now pre-populated correctly when the Admin Panel page loads
- Follows the same pattern already established in `Settings.jsx`

## Changes

- `frontend/src/pages/AdminPanel.jsx`: Added `useEffect` to React import, removed `onSuccess` from both `useQuery` calls, added `useEffect` hooks to sync query data into local state

## Test Plan

- [ ] Navigate to the Admin Panel
- [ ] Verify the retention days input field is pre-populated with the current server value
- [ ] Verify the due soon days, update check enabled, and update check interval fields are pre-populated
- [ ] Verify that saving any setting still works correctly

## References

Closes #177

Implementation plan: https://github.com/derekwinters/chores-web/issues/177#issuecomment-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)