### PR TITLE
fix: Normalize boolean config storage and export coercion (#162)

### DIFF
--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -88,9 +88,9 @@ async def update_config(body: ConfigUpdate, current_user: str = Depends(get_curr
         result = await db.execute(select(Settings).where(Settings.key == "auth_enabled"))
         settings_row = result.scalar_one_or_none()
         if settings_row:
-            settings_row.value = str(body.auth_enabled)
+            settings_row.value = str(body.auth_enabled).lower()
         else:
-            settings_row = Settings(key="auth_enabled", value=str(body.auth_enabled))
+            settings_row = Settings(key="auth_enabled", value=str(body.auth_enabled).lower())
             db.add(settings_row)
 
     if body.timezone is not None:
@@ -115,9 +115,9 @@ async def update_config(body: ConfigUpdate, current_user: str = Depends(get_curr
         result = await db.execute(select(Settings).where(Settings.key == "update_check_enabled"))
         settings_row = result.scalar_one_or_none()
         if settings_row:
-            settings_row.value = str(body.update_check_enabled)
+            settings_row.value = str(body.update_check_enabled).lower()
         else:
-            settings_row = Settings(key="update_check_enabled", value=str(body.update_check_enabled))
+            settings_row = Settings(key="update_check_enabled", value=str(body.update_check_enabled).lower())
             db.add(settings_row)
 
     if body.update_check_interval is not None:

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -28,12 +28,33 @@ def extract_fields(obj: Any, model_type: str) -> dict:
     return result
 
 
+BOOL_CONFIG_KEYS = {"auth_enabled", "update_check_enabled"}
+INT_CONFIG_KEYS = {"due_soon_days", "update_check_interval"}
+
+
+def coerce_config_value(key: str, value: str) -> Any:
+    """Coerce a string setting value to its proper Python type for JSON export.
+
+    Handles both old Python-stringified booleans ("True"/"False") and
+    canonical lowercase forms ("true"/"false") so exports always contain
+    real JSON booleans and integers rather than quoted strings.
+    """
+    if key in BOOL_CONFIG_KEYS:
+        return value.lower() == "true"
+    if key in INT_CONFIG_KEYS:
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
 async def generate_export(people: list, chores: list, settings: list) -> dict:
     schema_version = compute_schema_version()
 
     config_dict = {}
     for setting in settings:
-        config_dict[setting.key] = setting.value
+        config_dict[setting.key] = coerce_config_value(setting.key, setting.value)
 
     return {
         "schemaVersion": schema_version,

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Person, Chore, Settings
 from ..security import hash_password
-from .export_service import compute_schema_version, EXPORT_SCHEMA
+from .export_service import compute_schema_version, EXPORT_SCHEMA, BOOL_CONFIG_KEYS, INT_CONFIG_KEYS
 
 DEFAULT_IMPORT_PASSWORD = "password"
 
@@ -102,7 +102,24 @@ async def import_config(
             db.add(chore)
 
         for key, value in data.get("config", {}).items():
-            setting = Settings(key=key, value=value)
+            # Normalize boolean and integer config values to canonical string form.
+            # This prevents re-introducing Python-stringified "True"/"False" when
+            # importing old backups that pre-date this fix.
+            if key in BOOL_CONFIG_KEYS:
+                # Accept both Python ("True") and JSON ("true") boolean strings as
+                # well as actual booleans (if the import file has already been fixed).
+                if isinstance(value, bool):
+                    normalized = str(value).lower()
+                else:
+                    normalized = "true" if str(value).lower() == "true" else "false"
+            elif key in INT_CONFIG_KEYS:
+                try:
+                    normalized = str(int(value))
+                except (ValueError, TypeError):
+                    normalized = str(value)
+            else:
+                normalized = str(value) if not isinstance(value, str) else value
+            setting = Settings(key=key, value=normalized)
             db.add(setting)
 
         await db.commit()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for config endpoints."""
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Settings
@@ -153,6 +154,32 @@ async def test_update_config_due_soon_days_boundary_high(authenticated_client: A
     assert r.status_code == 200
     data = r.json()
     assert data["due_soon_days"] == 365
+
+
+@pytest.mark.asyncio
+async def test_update_config_auth_enabled_stores_lowercase(authenticated_client: AsyncClient, db: AsyncSession):
+    """Test that PUT /config with auth_enabled=false stores lowercase 'false' in the DB, not Python 'False'."""
+    r = await authenticated_client.put("/config", json={"auth_enabled": False})
+    assert r.status_code == 200
+    assert r.json()["auth_enabled"] is False
+
+    result = await db.execute(select(Settings).where(Settings.key == "auth_enabled"))
+    setting = result.scalar_one_or_none()
+    assert setting is not None
+    assert setting.value == "false", f"Expected 'false' but got '{setting.value}'"
+
+
+@pytest.mark.asyncio
+async def test_update_config_update_check_enabled_stores_lowercase(authenticated_client: AsyncClient, db: AsyncSession):
+    """Test that PUT /config with update_check_enabled=false stores lowercase 'false' in the DB."""
+    r = await authenticated_client.put("/config", json={"update_check_enabled": False})
+    assert r.status_code == 200
+    assert r.json()["update_check_enabled"] is False
+
+    result = await db.execute(select(Settings).where(Settings.key == "update_check_enabled"))
+    setting = result.scalar_one_or_none()
+    assert setting is not None
+    assert setting.value == "false", f"Expected 'false' but got '{setting.value}'"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -3,7 +3,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Person, Chore
+from app.models import Person, Chore, Settings
 
 
 @pytest.mark.asyncio
@@ -63,3 +63,57 @@ async def test_export_config(client: AsyncClient, db: AsyncSession):
 
     # Check config is dict
     assert isinstance(data["config"], dict)
+
+
+@pytest.mark.asyncio
+async def test_export_config_boolean_types(client: AsyncClient, db: AsyncSession):
+    """Test that exported config has real JSON booleans and integers, not quoted strings.
+
+    Regression test for https://github.com/derekwinters/chores-web/issues/162:
+    auth_enabled was exported as string "True" instead of boolean true.
+    """
+    # Login
+    login_r = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin_password"}
+    )
+    assert login_r.status_code == 200
+    token = login_r.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Seed the DB with old-style Python-stringified booleans to simulate pre-fix data
+    from sqlalchemy import select
+
+    for key, old_value in [("auth_enabled", "True"), ("update_check_enabled", "False")]:
+        result = await db.execute(select(Settings).where(Settings.key == key))
+        setting = result.scalar_one_or_none()
+        if setting:
+            setting.value = old_value
+        else:
+            db.add(Settings(key=key, value=old_value))
+
+    for key, old_value in [("due_soon_days", "7"), ("update_check_interval", "48")]:
+        result = await db.execute(select(Settings).where(Settings.key == key))
+        setting = result.scalar_one_or_none()
+        if setting:
+            setting.value = old_value
+        else:
+            db.add(Settings(key=key, value=old_value))
+
+    await db.commit()
+
+    # Export
+    export_r = await client.get("/export/config", headers=headers)
+    assert export_r.status_code == 200
+    data = export_r.json()
+
+    config = data["config"]
+    assert isinstance(config, dict)
+
+    # Boolean keys must be actual booleans, not strings
+    assert config["auth_enabled"] is True, f"auth_enabled should be bool True, got {config['auth_enabled']!r}"
+    assert config["update_check_enabled"] is False, f"update_check_enabled should be bool False, got {config['update_check_enabled']!r}"
+
+    # Integer keys must be actual integers, not strings
+    assert config["due_soon_days"] == 7, f"due_soon_days should be int 7, got {config['due_soon_days']!r}"
+    assert config["update_check_interval"] == 48, f"update_check_interval should be int 48, got {config['update_check_interval']!r}"


### PR DESCRIPTION
## Summary

- Boolean settings (`auth_enabled`, `update_check_enabled`) were stored by Python's `str()` as `"True"`/`"False"`, causing backups to emit quoted strings instead of proper JSON booleans.
- `export_service` now coerces stored string values to their correct Python types (`bool`, `int`) before serialisation so exports always contain real JSON booleans and integers.
- `import_service` normalises both old-style Python-stringified and canonical lowercase boolean/integer values on ingestion, making old backups transparently correctable.
- `config` router writes boolean settings with `.lower()` going forward so no new bad data is produced.

## Test plan

- [ ] Run `pytest backend/tests/test_config.py` — new tests assert the DB stores `"true"`/`"false"` (lowercase)
- [ ] Run `pytest backend/tests/test_export.py` — new regression test seeds old `"True"`/`"False"` values and verifies the export returns actual JSON `true`/`false` and integer types
- [ ] Manually export a backup and confirm `auth_enabled` is `true` (boolean), not `"True"` (string)
- [ ] Import an old backup containing `"True"` strings and verify the imported settings are normalised

## Related

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)