### PR TITLE
fix: Show state diagram on transitions, add test planning to plan agent

### DIFF
--- a/.claude/agents/github-issue-implementation-orchestrator.md
+++ b/.claude/agents/github-issue-implementation-orchestrator.md
@@ -8,6 +8,10 @@ type: agent
 
 Automated workflow coordinator for implementing GitHub issues end-to-end. Implements 8-state machine to guide issues through branch creation, implementation, testing, and pull request creation.
 
+## IMPORTANT: Display Workflow Diagram on Every State Transition
+
+Display the workflow diagram each time you transition to a new state, immediately before executing that state's work. Highlight the destination state with heavy borders. This provides a visual checkpoint at every step of the 8-state machine.
+
 ## State Machine & Skill Orchestration
 
 ```
@@ -61,7 +65,7 @@ START
 
 ## Output Format
 
-Agent outputs workflow diagram at top of every response, highlighting current stage:
+Agent outputs workflow diagram on each state transition, highlighting the destination stage:
 
 ```
 GITHUB ISSUE IMPLEMENTATION WORKFLOW
@@ -141,7 +145,7 @@ Resumable by checking current branch state and git status.
 
 Orchestrator:
 - Calls skills in sequence
-- Displays state progress at start of each response
+- Displays state diagram on each state transition
 - Manages pause points for user review
 - Routes loops (e.g., changes requested → return to implement)
 - Returns final PR URL

--- a/.claude/agents/github-issue-plan-orchestrator.md
+++ b/.claude/agents/github-issue-plan-orchestrator.md
@@ -8,6 +8,10 @@ type: agent
 
 Automated workflow coordinator for comprehensive GitHub issue planning. Implements 7-state machine to guide issues through exploration, proposal, user review, and finalization.
 
+## IMPORTANT: Display Workflow Diagram on Every State Transition
+
+Display the workflow diagram each time you transition to a new state, immediately before executing that state's work. Highlight the destination state with heavy borders (┏┓┗┛, ┃). This provides a visual checkpoint at every step of the 7-state machine.
+
 ## State Machine
 
 ```
@@ -34,6 +38,11 @@ START
   │  ├─ Trace call paths: router → service → model → DB
   │  ├─ Study similar existing implementations for patterns
   │  └─ Identify exact files/functions requiring changes
+  ├─ Identify affected tests
+  │  ├─ Find existing tests covering changed code (grep test files for function/route names)
+  │  ├─ Flag tests that will break due to signature, schema, or behavior changes
+  │  ├─ Identify gaps: new code paths with no test coverage
+  │  └─ Note tests to remove if functionality is deleted
   └─ Continue
           ↓
 [3] propose (auto)
@@ -47,7 +56,9 @@ START
   │  │  ├─ Schema modifications if applicable
   │  │  └─ UI/UX changes with examples
   │  ├─ Testing Approach
-  │  │  ├─ Unit tests (specific test files)
+  │  │  ├─ Tests to modify: exact file paths + what changes and why
+  │  │  ├─ Tests to add: specific cases for new behavior, with file locations
+  │  │  ├─ Tests to remove: dead tests for deleted functionality
   │  │  ├─ Integration/API tests
   │  │  └─ Manual UI testing in browser (critical)
   │  └─ Potential Challenges
@@ -75,7 +86,7 @@ START
   ├─ Format final plan summary (markdown)
   ├─ Post plan as issue comment
   │  ├─ gh issue comment <number> --body "<formatted-plan>"
-  │  └─ Include: affected files, steps, testing, challenges, rationale
+  │  └─ Include: affected files, steps, test changes (modify/add/remove), challenges, rationale
   ├─ Remove ready-to-plan label
   │  └─ gh issue edit <number> --remove-label ready-to-plan
   ├─ Add ready-for-work label
@@ -157,7 +168,7 @@ Updated after each state transition. Allows resumption of in-progress planning.
 
 ## Output Format
 
-Agent outputs workflow diagram at top of every response, highlighting current stage:
+Agent outputs workflow diagram on each state transition, highlighting the destination stage:
 
 ```
 GITHUB ISSUE PLAN WORKFLOW
@@ -187,4 +198,4 @@ GITHUB ISSUE PLAN WORKFLOW
 - Proposal refinement loops until user approval
 - Plan posting happens only after explicit approval
 - Labels updated atomically with plan posting
-- Diagram shown on every response to provide visual context of current progress
+- Diagram shown on each state transition to provide visual context of progress

--- a/.claude/agents/github-issue-triage-orchestrator.md
+++ b/.claude/agents/github-issue-triage-orchestrator.md
@@ -8,6 +8,10 @@ type: agent
 
 Automated workflow coordinator for GitHub issue triage. Implements 9-state machine to guide issues through validation, feedback, labeling, and milestone assignment.
 
+## IMPORTANT: Display Workflow Diagram on Every State Transition
+
+Display the workflow diagram each time you transition to a new state, immediately before executing that state's work. Highlight the destination state with heavy borders. This provides a visual checkpoint at every step of the 9-state machine.
+
 ## State Machine
 
 ```
@@ -122,7 +126,7 @@ Updated after each state transition.
 
 ## Output Format
 
-Agent outputs workflow diagram at top of every response, highlighting current stage:
+Agent outputs workflow diagram on each state transition, highlighting the destination stage:
 
 ```
 GITHUB ISSUE TRIAGE WORKFLOW
@@ -150,4 +154,4 @@ GITHUB ISSUE TRIAGE WORKFLOW
 - State persists in issue comments
 - User pause is graceful (no auto-closing)
 - Validators control exact label suggestions
-- Diagram shown on every response to provide visual context of current progress
+- Diagram shown on each state transition to provide visual context of progress


### PR DESCRIPTION
## Summary

- All three orchestrator agents now display the workflow diagram on each state transition (not every response), immediately before executing the new state's work
- Plan orchestrator `explore` state now identifies affected tests: existing tests covering changed code, tests that will break, coverage gaps requiring new tests, dead tests to remove
- Plan orchestrator `propose` state testing section now explicitly enumerates tests to modify/add/remove with exact file paths

## Test plan

- [ ] Trigger triage/plan/implementation orchestrators and verify diagram appears at each state transition, not just on first response
- [ ] Trigger plan orchestrator and verify output includes test impact analysis (broken, new, removed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)