### PR TITLE
fix: resync sequences and stamp initial revision on DuplicateTable (#193)

### DIFF
--- a/backend/alembic/versions/b2c3d4e5f6a1_resync_sequences_to_table_data.py
+++ b/backend/alembic/versions/b2c3d4e5f6a1_resync_sequences_to_table_data.py
@@ -1,0 +1,51 @@
+"""Resync sequences to table data
+
+Revision ID: b2c3d4e5f6a1
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-09 00:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6a1'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Only run on PostgreSQL — SQLite does not have sequences
+    bind = op.get_bind()
+    if bind.dialect.name != 'postgresql':
+        return
+
+    tables = [
+        'people',
+        'token_blacklist',
+        'chores',
+        'points_log',
+        'redemption_log',
+        'chore_log',
+        'settings',
+        'update_checks',
+    ]
+
+    for table in tables:
+        # Advance sequence to GREATEST(MAX(id), last_value) so it only moves forward.
+        # COALESCE handles empty tables where MAX(id) is NULL.
+        op.execute(f"""
+            SELECT SETVAL(
+                '{table}_id_seq',
+                GREATEST(
+                    COALESCE((SELECT MAX(id) FROM {table}), 0),
+                    (SELECT last_value FROM {table}_id_seq)
+                )
+            );
+        """)
+
+
+def downgrade() -> None:
+    # Sequences cannot be safely wound back — downgrade is a no-op
+    pass

--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -1,11 +1,31 @@
 """Database migrations using Alembic."""
-import asyncio
 import subprocess
 import sys
 from pathlib import Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .database import set_db_status, set_migrations_in_progress, DatabaseStatus
+
+# Revision that establishes the initial schema — used as a safe stamp target
+# when the database already has tables but no Alembic version row yet.
+_INITIAL_REVISION = '6809073594f7'
+
+
+def _get_current_revision(backend_dir: Path) -> str | None:
+    """Return the current Alembic revision, or None if unavailable."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "alembic", "current"],
+            cwd=backend_dir,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except Exception:
+        pass
+    return None
 
 
 async def apply_migrations(db: AsyncSession):
@@ -22,27 +42,57 @@ async def apply_migrations(db: AsyncSession):
             timeout=30
         )
 
-        # Check for "DuplicateTable" error (existing schema) - not a failure
-        if "DuplicateTable" in proc.stderr or "already exists" in proc.stderr:
-            # Schema already exists from previous run, stamp as applied
-            print("Database schema already exists, marking migrations as applied")
+        # Check for "DuplicateTable" error indicating a pre-existing schema
+        # that was created before Alembic tracking began.
+        if "DuplicateTable" in proc.stderr:
+            current = _get_current_revision(backend_dir)
+
+            if current and "(head)" in current:
+                # Already fully up-to-date — nothing to do.
+                set_db_status(DatabaseStatus.READY)
+                print("Database already at head revision, no migrations needed")
+                return
+
+            # Stamp only the initial revision so that all later migrations
+            # (including sequence resync) still execute on the next upgrade.
+            print(
+                "Pre-existing schema detected (DuplicateTable). "
+                f"Stamping initial revision {_INITIAL_REVISION} and re-running upgrade."
+            )
             try:
                 stamp_proc = subprocess.run(
-                    [sys.executable, "-m", "alembic", "stamp", "head"],
+                    [sys.executable, "-m", "alembic", "stamp", _INITIAL_REVISION],
                     cwd=backend_dir,
                     capture_output=True,
                     text=True,
                     timeout=10
                 )
-                if stamp_proc.returncode == 0:
+                if stamp_proc.returncode != 0:
+                    print(
+                        f"Warning stamping initial revision: {stamp_proc.stderr}",
+                        file=sys.stderr
+                    )
+
+                # Re-run upgrade so pending migrations execute.
+                upgrade_proc = subprocess.run(
+                    [sys.executable, "-m", "alembic", "upgrade", "head"],
+                    cwd=backend_dir,
+                    capture_output=True,
+                    text=True,
+                    timeout=30
+                )
+                if upgrade_proc.returncode == 0:
                     set_db_status(DatabaseStatus.READY)
-                    print("Database migrations stamped successfully")
+                    print("Database migrations applied successfully after stamp")
                 else:
-                    print(f"Warning stamping migrations: {stamp_proc.stderr}", file=sys.stderr)
-                    set_db_status(DatabaseStatus.READY)
+                    print(
+                        f"Alembic migration warning after stamp: {upgrade_proc.stderr}",
+                        file=sys.stderr
+                    )
+                    set_db_status(DatabaseStatus.ERROR)
             except Exception as e:
-                print(f"Warning: Could not stamp migrations: {e}", file=sys.stderr)
-                set_db_status(DatabaseStatus.READY)
+                print(f"Warning: Could not stamp/upgrade migrations: {e}", file=sys.stderr)
+                set_db_status(DatabaseStatus.ERROR)
         elif proc.returncode != 0:
             set_db_status(DatabaseStatus.ERROR)
             print(f"Alembic migration warning: {proc.stderr}", file=sys.stderr)

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,172 @@
+"""Unit tests for database migration startup logic in app/migrations.py."""
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from app.database import DatabaseStatus
+from app.migrations import apply_migrations, _INITIAL_REVISION
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    """Return a mock CompletedProcess."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Test: normal success path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_success_path():
+    """Normal upgrade with no errors sets status to READY."""
+    db = AsyncMock()
+    success_proc = _make_proc(returncode=0, stdout="", stderr="")
+
+    with patch("app.migrations.subprocess.run", return_value=success_proc) as mock_run, \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress") as mock_in_progress:
+
+        await apply_migrations(db)
+
+        mock_set_status.assert_called_once_with(DatabaseStatus.READY)
+        # upgrade called exactly once
+        assert mock_run.call_count == 1
+        assert "upgrade" in mock_run.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Test: error path (non-duplicate failure)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_error_path():
+    """A non-duplicate error sets status to ERROR."""
+    db = AsyncMock()
+    error_proc = _make_proc(returncode=1, stdout="", stderr="FATAL: connection refused")
+
+    with patch("app.migrations.subprocess.run", return_value=error_proc), \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress"):
+
+        await apply_migrations(db)
+
+        mock_set_status.assert_called_once_with(DatabaseStatus.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Test: "already exists" in stderr does NOT trigger stamping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_does_not_stamp_on_arbitrary_already_exists():
+    """'already exists' without 'DuplicateTable' is treated as a real error, not a stamp trigger."""
+    db = AsyncMock()
+    # Some other error message that happens to include "already exists"
+    error_proc = _make_proc(returncode=1, stdout="", stderr="constraint already exists")
+
+    with patch("app.migrations.subprocess.run", return_value=error_proc), \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress"):
+
+        await apply_migrations(db)
+
+        # Should be ERROR, not READY — stamping must NOT be triggered
+        mock_set_status.assert_called_once_with(DatabaseStatus.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Test: DuplicateTable when already at head → no stamp, READY
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_already_at_head_skips_stamp():
+    """When DuplicateTable appears but current revision is already head, skip stamping."""
+    db = AsyncMock()
+    dup_proc = _make_proc(returncode=1, stderr="DuplicateTable: relation 'chores' already exists")
+    current_proc = _make_proc(returncode=0, stdout="b2c3d4e5f6a1 (head)")
+
+    with patch("app.migrations.subprocess.run", side_effect=[dup_proc, current_proc]) as mock_run, \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress"):
+
+        await apply_migrations(db)
+
+        mock_set_status.assert_called_once_with(DatabaseStatus.READY)
+        # upgrade + current — no stamp or second upgrade
+        assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: DuplicateTable stamps initial revision then re-runs upgrade
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_stamps_initial_then_reruns_upgrade():
+    """DuplicateTable with pending migrations stamps initial revision and re-runs upgrade."""
+    db = AsyncMock()
+    dup_proc    = _make_proc(returncode=1, stderr="DuplicateTable: relation 'chores' already exists")
+    current_proc = _make_proc(returncode=0, stdout="6809073594f7")   # at initial, not head
+    stamp_proc  = _make_proc(returncode=0)
+    upgrade2_proc = _make_proc(returncode=0)
+
+    side_effects = [dup_proc, current_proc, stamp_proc, upgrade2_proc]
+
+    with patch("app.migrations.subprocess.run", side_effect=side_effects) as mock_run, \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress"):
+
+        await apply_migrations(db)
+
+        mock_set_status.assert_called_once_with(DatabaseStatus.READY)
+        calls = mock_run.call_args_list
+
+        # First call: upgrade head
+        assert "upgrade" in calls[0][0][0]
+        # Second call: alembic current
+        assert "current" in calls[1][0][0]
+        # Third call: stamp _INITIAL_REVISION
+        assert "stamp" in calls[2][0][0]
+        assert _INITIAL_REVISION in calls[2][0][0]
+        # Fourth call: upgrade head again
+        assert "upgrade" in calls[3][0][0]
+
+
+# ---------------------------------------------------------------------------
+# Test: pending migrations still run after stamp (resync migration executes)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_migrations_pending_migrations_run_after_stamp():
+    """After stamping the initial revision, the re-run upgrade processes pending migrations."""
+    db = AsyncMock()
+    dup_proc     = _make_proc(returncode=1, stderr="DuplicateTable: relation 'people' already exists")
+    current_proc = _make_proc(returncode=0, stdout="")   # empty — not at head
+    stamp_proc   = _make_proc(returncode=0)
+    # Simulate the resync migration running during the second upgrade
+    upgrade2_proc = _make_proc(
+        returncode=0,
+        stdout="Running upgrade 6809073594f7 -> b2c3d4e5f6a1, Resync sequences to table data"
+    )
+
+    with patch("app.migrations.subprocess.run",
+               side_effect=[dup_proc, current_proc, stamp_proc, upgrade2_proc]) as mock_run, \
+         patch("app.migrations.set_db_status") as mock_set_status, \
+         patch("app.migrations.set_migrations_in_progress"):
+
+        await apply_migrations(db)
+
+        mock_set_status.assert_called_once_with(DatabaseStatus.READY)
+        # Confirm four subprocess calls were made
+        assert mock_run.call_count == 4
+        # The second upgrade output mentions the resync migration
+        last_call_result = mock_run.call_args_list[3]
+        assert "upgrade" in last_call_result[0][0]


### PR DESCRIPTION
## Summary

- Adds Alembic migration `b2c3d4e5f6a1` that resets every table's primary-key sequence to `MAX(id)+1`, eliminating "ID X already exists" duplicate-key errors caused by out-of-sync sequences after restores or manual inserts.
- Fixes `migrations.py` to stamp only the **initial revision** (not `head`) when a pre-existing schema is detected via `DuplicateTable`, so the sequence-resync migration and any other post-init migrations still execute on the subsequent upgrade.
- Adds a `_get_current_revision` helper to avoid redundant stamping when the database is already at head.

Closes #193

## Test plan

- [ ] Unit tests in `backend/tests/test_migrations.py` cover DuplicateTable stamping path, already-at-head short-circuit, and normal upgrade path.
- [ ] Deploy to a database that has existing rows; verify sequences are reset and new chores can be created without duplicate-key errors.
- [ ] Deploy to a fresh database; verify normal migration path is unaffected.
- [ ] Redeploy services (no DB wipe); verify creating a chore succeeds after the sequence-resync migration runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)