### PR TITLE
feat: Log user goal value changes and unlogged chore modifications (#107)

### DIFF
--- a/backend/alembic/versions/c3d4e5f6a1b2_add_user_log_table.py
+++ b/backend/alembic/versions/c3d4e5f6a1b2_add_user_log_table.py
@@ -1,0 +1,50 @@
+"""Add user_log table
+
+Revision ID: c3d4e5f6a1b2
+Revises: b2c3d4e5f6a1
+Create Date: 2026-05-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c3d4e5f6a1b2'
+down_revision = 'b2c3d4e5f6a1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create user_log table
+    op.create_table(
+        'user_log',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('person_id', sa.Integer(), nullable=False),
+        sa.Column('person_name', sa.Text(), nullable=False),
+        sa.Column('action', sa.Text(), nullable=False),
+        sa.Column('field_name', sa.Text(), nullable=True),
+        sa.Column('old_value', sa.Text(), nullable=True),
+        sa.Column('new_value', sa.Text(), nullable=True),
+        sa.Column('changed_by', sa.Text(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    # Create sequence for auto-increment ID (PostgreSQL only)
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute("CREATE SEQUENCE IF NOT EXISTS user_log_id_seq;")
+        op.execute("""
+            ALTER TABLE user_log
+            ALTER COLUMN id SET DEFAULT nextval('user_log_id_seq');
+        """)
+
+
+def downgrade() -> None:
+    op.drop_table('user_log')
+
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute("DROP SEQUENCE IF EXISTS user_log_id_seq;")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -98,6 +98,20 @@ class ChoreLog(Base):
     new_value: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
 
+class UserLog(Base):
+    __tablename__ = "user_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    person_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    person_name: Mapped[str] = mapped_column(Text, nullable=False)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    field_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    old_value: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    new_value: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    changed_by: Mapped[str] = mapped_column(Text, nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 class Settings(Base):
     __tablename__ = "settings"
 

--- a/backend/app/routers/chores.py
+++ b/backend/app/routers/chores.py
@@ -355,7 +355,7 @@ async def action_skip_reassign(chore_id: int, body: SkipReassignBody, current_us
 async def action_reassign(chore_id: int, body: ReassignBody, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     await _validate_people_exist(db, None, body.assignee)
     chore = await _get_or_404(chore_id, db)
-    return _enrich(await reassign_chore(chore, db, assignee=body.assignee))
+    return _enrich(await reassign_chore(chore, db, assignee=body.assignee, person=current_user))
 
 
 @router.post("/{chore_id}/mark-due", response_model=ChoreOut)

--- a/backend/app/routers/log.py
+++ b/backend/app/routers/log.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
 from ..database import get_db
-from ..models import ChoreLog
+from ..models import ChoreLog, UserLog
 from ..schemas import ChoreLogOut
 from ..dependencies import get_current_user, require_admin
 
@@ -17,6 +17,22 @@ _log_retention_days = 90
 
 class RetentionSettings(BaseModel):
     retention_days: int
+
+
+def _user_log_to_chore_log_out(entry: UserLog) -> ChoreLogOut:
+    """Convert a UserLog row into ChoreLogOut shape for the unified log response."""
+    return ChoreLogOut(
+        id=entry.id,
+        chore_id=0,
+        chore_name=f"Person: {entry.person_name}",
+        person=entry.changed_by,
+        action=entry.action,
+        timestamp=entry.timestamp,
+        reassigned_to=None,
+        field_name=entry.field_name,
+        old_value=entry.old_value,
+        new_value=entry.new_value,
+    )
 
 
 @router.get("", response_model=list[ChoreLogOut])
@@ -30,23 +46,50 @@ async def get_log(
     current_user: str = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    query = select(ChoreLog).order_by(ChoreLog.timestamp.desc())
+    # --- ChoreLog query ---
+    chore_query = select(ChoreLog)
 
     if person:
-        query = query.where(ChoreLog.person.ilike(person))
+        chore_query = chore_query.where(ChoreLog.person.ilike(person))
     if chore_id:
-        query = query.where(ChoreLog.chore_id == int(chore_id))
+        # chore_id=0 is the UserLog sentinel — exclude it from chore query
+        chore_query = chore_query.where(ChoreLog.chore_id == int(chore_id))
     if action:
-        query = query.where(ChoreLog.action == action)
+        chore_query = chore_query.where(ChoreLog.action == action)
     if actions:
-        query = query.where(ChoreLog.action.in_(actions))
+        chore_query = chore_query.where(ChoreLog.action.in_(actions))
     if start_date:
-        query = query.where(ChoreLog.timestamp >= datetime.combine(start_date, datetime.min.time()))
+        chore_query = chore_query.where(ChoreLog.timestamp >= datetime.combine(start_date, datetime.min.time()))
     if end_date:
-        query = query.where(ChoreLog.timestamp <= datetime.combine(end_date, datetime.max.time()))
+        chore_query = chore_query.where(ChoreLog.timestamp <= datetime.combine(end_date, datetime.max.time()))
 
-    result = await db.execute(query)
-    return result.scalars().all()
+    chore_result = await db.execute(chore_query)
+    chore_entries = list(chore_result.scalars().all())
+
+    # --- UserLog query (skip when a specific real chore_id is requested) ---
+    user_entries: list[ChoreLogOut] = []
+    if not chore_id or int(chore_id) == 0:
+        user_query = select(UserLog)
+
+        if person:
+            user_query = user_query.where(UserLog.changed_by.ilike(person))
+        if action:
+            user_query = user_query.where(UserLog.action == action)
+        if actions:
+            user_query = user_query.where(UserLog.action.in_(actions))
+        if start_date:
+            user_query = user_query.where(UserLog.timestamp >= datetime.combine(start_date, datetime.min.time()))
+        if end_date:
+            user_query = user_query.where(UserLog.timestamp <= datetime.combine(end_date, datetime.max.time()))
+
+        user_result = await db.execute(user_query)
+        user_entries = [_user_log_to_chore_log_out(e) for e in user_result.scalars().all()]
+
+    # Merge and sort descending by timestamp
+    chore_outs = [ChoreLogOut.model_validate(e) for e in chore_entries]
+    combined = chore_outs + user_entries
+    combined.sort(key=lambda e: e.timestamp, reverse=True)
+    return combined
 
 
 @router.get("/retention", response_model=RetentionSettings)
@@ -68,6 +111,7 @@ async def set_retention(
 
     cutoff_date = datetime.now() - timedelta(days=_log_retention_days)
     await db.execute(delete(ChoreLog).where(ChoreLog.timestamp < cutoff_date))
+    await db.execute(delete(UserLog).where(UserLog.timestamp < cutoff_date))
     await db.commit()
 
     return RetentionSettings(retention_days=_log_retention_days)

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -9,6 +9,7 @@ from ..models import Person, RedemptionLog
 from ..schemas import PersonCreate, PersonOut, PersonUpdate, PersonRedemption, RedemptionLogOut
 from ..dependencies import get_current_user, require_admin
 from ..security import hash_password
+from ..services.logging import log_person_change
 
 router = APIRouter(prefix="/people", tags=["people"])
 
@@ -55,6 +56,10 @@ async def update_person(person_id: int, body: PersonUpdate, current_user: str = 
         if existing.scalar_one_or_none():
             raise HTTPException(status_code=409, detail="Username already exists")
 
+    # Loggable fields: capture old values before mutation
+    loggable_fields = ["name", "username", "color", "goal_7d", "goal_30d", "is_admin", "preferred_theme"]
+    old_values = {f: getattr(person, f) for f in loggable_fields}
+
     updates = {
         "name": body.name,
         "username": body.username,
@@ -62,6 +67,7 @@ async def update_person(person_id: int, body: PersonUpdate, current_user: str = 
         "goal_7d": body.goal_7d,
         "goal_30d": body.goal_30d,
         "is_admin": body.is_admin,
+        "preferred_theme": body.preferred_theme,
     }
 
     for field, value in updates.items():
@@ -69,7 +75,34 @@ async def update_person(person_id: int, body: PersonUpdate, current_user: str = 
             setattr(person, field, value)
 
     if body.password:
+        old_pw = person.password_hash
         person.password_hash = hash_password(body.password)
+        await log_person_change(
+            person_id=person.id,
+            person_name=person.name,
+            action="updated",
+            changed_by=current_user,
+            db=db,
+            field_name="password",
+            old_value=old_pw,
+            new_value="set",
+        )
+
+    # Log each changed loggable field
+    for field in loggable_fields:
+        new_val = getattr(person, field)
+        old_val = old_values[field]
+        if old_val != new_val:
+            await log_person_change(
+                person_id=person.id,
+                person_name=person.name,
+                action="updated",
+                changed_by=current_user,
+                db=db,
+                field_name=field,
+                old_value=None if old_val is None else str(old_val),
+                new_value=None if new_val is None else str(new_val),
+            )
 
     await db.commit()
     await db.refresh(person)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -183,6 +183,21 @@ class ChoreLogOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class UserLogOut(BaseModel):
+    id: int
+    chore_id: int
+    chore_name: str
+    person: str
+    action: str
+    timestamp: datetime
+    reassigned_to: Optional[str] = None
+    field_name: Optional[str] = None
+    old_value: Optional[str] = None
+    new_value: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
 class LeaderboardEntry(BaseModel):
     person: str
     total_points: int

--- a/backend/app/services/chore_service.py
+++ b/backend/app/services/chore_service.py
@@ -276,6 +276,7 @@ async def skip_and_reassign_chore(
     assignee: Optional[str] = None,
     skipped_by: Optional[str] = None,
 ) -> Chore:
+    old_assignee = chore.current_assignee
     chore = await skip_chore(chore, db, skipped_by=skipped_by)
 
     if assignee:
@@ -286,13 +287,22 @@ async def skip_and_reassign_chore(
         chore.rotation_index = (chore.rotation_index + 1) % len(chore.eligible_people)
         chore.current_assignee = chore.eligible_people[chore.rotation_index]
 
+    if chore.current_assignee != old_assignee:
+        await _log_action(
+            chore,
+            CHANGE_REASSIGNED,
+            skipped_by or "system",
+            db,
+            reassigned_to=chore.current_assignee,
+        )
+
     db.add(chore)
     await db.commit()
     await db.refresh(chore)
     return chore
 
 
-async def reassign_chore(chore: Chore, db: AsyncSession, assignee: str) -> Chore:
+async def reassign_chore(chore: Chore, db: AsyncSession, assignee: str, person: str = "system") -> Chore:
     chore.current_assignee = assignee
     if chore.assignment_type == "rotating" and assignee in chore.eligible_people:
         chore.rotation_index = chore.eligible_people.index(assignee)
@@ -300,7 +310,7 @@ async def reassign_chore(chore: Chore, db: AsyncSession, assignee: str) -> Chore
     chore.last_changed_by = None
     chore.last_change_type = CHANGE_REASSIGNED
 
-    await _log_action(chore, CHANGE_REASSIGNED, "system", db, reassigned_to=assignee)
+    await _log_action(chore, CHANGE_REASSIGNED, person, db, reassigned_to=assignee)
 
     db.add(chore)
     await db.commit()

--- a/backend/app/services/logging.py
+++ b/backend/app/services/logging.py
@@ -2,7 +2,7 @@ import logging
 import json
 from datetime import datetime, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
-from ..models import ChoreLog
+from ..models import ChoreLog, UserLog
 
 logger = logging.getLogger(__name__)
 
@@ -50,5 +50,57 @@ async def log_chore_change(
         old_value=old_value,
         new_value=new_value,
         reassigned_to=reassigned_to,
+    )
+    db.add(log)
+
+
+# Fields whose values must not be stored in plaintext
+_MASKED_FIELDS = {"password", "password_hash"}
+
+
+async def log_person_change(
+    person_id: int,
+    person_name: str,
+    action: str,
+    changed_by: str,
+    db: AsyncSession,
+    field_name: str | None = None,
+    old_value: str | None = None,
+    new_value: str | None = None,
+) -> None:
+    """Log a person field change or action."""
+    timestamp = datetime.now(timezone.utc)
+
+    # Mask sensitive fields
+    if field_name in _MASKED_FIELDS:
+        old_value = "changed" if old_value is not None else None
+        new_value = "changed" if new_value is not None else None
+
+    log_entry: dict = {
+        "timestamp": timestamp.isoformat(),
+        "person_id": person_id,
+        "person_name": person_name,
+        "action": action,
+        "changed_by": changed_by,
+    }
+
+    if field_name is not None:
+        log_entry["field_name"] = field_name
+    if old_value is not None:
+        log_entry["old_value"] = old_value
+    if new_value is not None:
+        log_entry["new_value"] = new_value
+
+    logger.info(json.dumps(log_entry))
+
+    log = UserLog(
+        person_id=person_id,
+        person_name=person_name,
+        action=action,
+        field_name=field_name,
+        old_value=old_value,
+        new_value=new_value,
+        changed_by=changed_by,
+        timestamp=timestamp,
     )
     db.add(log)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -695,11 +695,13 @@ class TestLogAPI:
         await authenticated_client.post(f"/chores/{chore_id}/reassign", json={"assignee": "Bob"})
         await authenticated_client.put(f"/chores/{chore_id}", json={"points": 9})
 
+        # After fixing reassign_chore to record the requesting user, testuser is now
+        # the actor for both completed and reassigned — both show up when filtering by testuser.
         r = await authenticated_client.get("/log?person=testuser&actions=completed&actions=reassigned")
         assert r.status_code == 200
         actions = [entry["action"] for entry in r.json()]
         assert "completed" in actions
-        assert "reassigned" not in actions
+        assert "reassigned" in actions  # testuser is now correctly recorded (not "system")
 
         r = await authenticated_client.get("/log?actions=completed&actions=reassigned")
         assert r.status_code == 200
@@ -707,3 +709,159 @@ class TestLogAPI:
         assert "completed" in actions
         assert "reassigned" in actions
         assert "updated" not in actions
+
+
+class TestUserLogAPI:
+    @pytest.mark.asyncio
+    async def test_goal_change_logged_in_unified_log(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        person_id = r.json()["id"]
+
+        r = await authenticated_client.put(f"/people/{person_id}", json={"goal_7d": 30})
+        assert r.status_code == 200
+
+        r = await authenticated_client.get("/log")
+        assert r.status_code == 200
+        logs = r.json()
+        person_entries = [e for e in logs if e["chore_name"].startswith("Person:")]
+        assert len(person_entries) >= 1
+        goal_entry = next(
+            (e for e in person_entries if e.get("field_name") == "goal_7d"),
+            None,
+        )
+        assert goal_entry is not None
+        assert goal_entry["old_value"] == "20"
+        assert goal_entry["new_value"] == "30"
+        assert goal_entry["action"] == "updated"
+
+    @pytest.mark.asyncio
+    async def test_goal_30d_change_logged(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
+        person_id = r.json()["id"]
+
+        await authenticated_client.put(f"/people/{person_id}", json={"goal_30d": 100})
+
+        r = await authenticated_client.get("/log")
+        logs = r.json()
+        entry = next(
+            (e for e in logs if e.get("field_name") == "goal_30d"),
+            None,
+        )
+        assert entry is not None
+        assert entry["old_value"] == "80"
+        assert entry["new_value"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_no_log_when_no_change(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Carol", "username": "carol"})
+        person_id = r.json()["id"]
+
+        # Send update with same value as default (goal_7d=20 already)
+        await authenticated_client.put(f"/people/{person_id}", json={"goal_7d": 20})
+
+        r = await authenticated_client.get("/log")
+        logs = r.json()
+        person_goal_entries = [
+            e for e in logs
+            if e["chore_name"].startswith("Person:") and e.get("field_name") == "goal_7d"
+        ]
+        assert len(person_goal_entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_password_change_masked_in_log(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Dave", "username": "dave"})
+        person_id = r.json()["id"]
+
+        await authenticated_client.put(f"/people/{person_id}", json={"password": "newpassword123"})
+
+        r = await authenticated_client.get("/log")
+        logs = r.json()
+        pw_entries = [e for e in logs if e.get("field_name") == "password"]
+        assert len(pw_entries) >= 1
+        assert pw_entries[0]["old_value"] == "changed"
+        assert pw_entries[0]["new_value"] == "changed"
+
+    @pytest.mark.asyncio
+    async def test_person_log_uses_sentinel_chore_id(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Eve", "username": "eve"})
+        person_id = r.json()["id"]
+        await authenticated_client.put(f"/people/{person_id}", json={"goal_7d": 25})
+
+        r = await authenticated_client.get("/log")
+        logs = r.json()
+        person_entries = [e for e in logs if e["chore_name"].startswith("Person:")]
+        assert all(e["chore_id"] == 0 for e in person_entries)
+
+    @pytest.mark.asyncio
+    async def test_person_log_excluded_when_real_chore_id_filtered(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Frank", "username": "frank"})
+        person_id = r.json()["id"]
+        await authenticated_client.put(f"/people/{person_id}", json={"goal_7d": 25})
+
+        # Create a chore so we have a real chore_id to filter on
+        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
+        chore_id = r.json()["id"]
+
+        r = await authenticated_client.get(f"/log?chore_id={chore_id}")
+        logs = r.json()
+        person_entries = [e for e in logs if e["chore_name"].startswith("Person:")]
+        assert len(person_entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_unified_log_sorted_by_timestamp_desc(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Grace", "username": "grace"})
+        person_id = r.json()["id"]
+
+        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+
+        await authenticated_client.put(f"/people/{person_id}", json={"goal_7d": 35})
+
+        r = await authenticated_client.get("/log")
+        assert r.status_code == 200
+        logs = r.json()
+        timestamps = [e["timestamp"] for e in logs]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_skip_reassign_logs_reassignment(self, authenticated_client):
+        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
+        r = await authenticated_client.post("/chores", json=ROTATING_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+
+        r = await authenticated_client.post(
+            f"/chores/{chore_id}/skip-reassign", json={"assignee": "Bob"}
+        )
+        assert r.status_code == 200
+
+        r = await authenticated_client.get(f"/log?chore_id={chore_id}&action=reassigned")
+        assert r.status_code == 200
+        logs = r.json()
+        assert len(logs) >= 1
+        assert logs[0]["action"] == "reassigned"
+        assert logs[0]["reassigned_to"] == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_reassign_logs_requesting_user(self, authenticated_client):
+        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
+        r = await authenticated_client.post("/chores", json=ROTATING_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+
+        r = await authenticated_client.post(
+            f"/chores/{chore_id}/reassign", json={"assignee": "Bob"}
+        )
+        assert r.status_code == 200
+
+        r = await authenticated_client.get(f"/log?chore_id={chore_id}&action=reassigned")
+        assert r.status_code == 200
+        logs = r.json()
+        assert len(logs) >= 1
+        reassign_log = next(e for e in logs if e["action"] == "reassigned")
+        # Should be the requesting user, not "system"
+        assert reassign_log["person"] == "testuser"

--- a/backend/tests/test_chore_service.py
+++ b/backend/tests/test_chore_service.py
@@ -1,8 +1,9 @@
 from datetime import date, datetime, timezone
 
 import pytest
+from sqlalchemy import select
 
-from app.models import Chore, PointsLog
+from app.models import Chore, ChoreLog, PointsLog
 from app.services.chore_service import (
     apply_assignment_state,
     complete_chore,
@@ -388,3 +389,92 @@ class TestTransitionOverdueChores:
 
         count = await transition_overdue_chores(db)
         assert count == 0
+
+
+class TestSkipAndReassignLogging:
+    @pytest.mark.asyncio
+    async def test_skip_and_reassign_logs_reassignment(self, db):
+        chore = _make_chore(
+            state="due",
+            schedule_type="interval",
+            schedule_config={"days": 7},
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob"],
+            current_assignee="Alice",
+            rotation_index=0,
+        )
+        db.add(chore)
+        await db.commit()
+        await db.refresh(chore)
+
+        await skip_and_reassign_chore(chore, db, assignee="Bob", skipped_by="alice")
+
+        logs = (await db.execute(select(ChoreLog))).scalars().all()
+        actions = [log.action for log in logs]
+        assert "skipped" in actions
+        assert "reassigned" in actions
+
+        reassign_log = next(log for log in logs if log.action == "reassigned")
+        assert reassign_log.reassigned_to == "Bob"
+        assert reassign_log.person == "alice"
+
+    @pytest.mark.asyncio
+    async def test_skip_and_reassign_no_extra_log_when_assignee_unchanged(self, db):
+        """When skip does not change current_assignee, no reassign log is emitted."""
+        chore = _make_chore(
+            state="due",
+            schedule_type="interval",
+            schedule_config={"days": 7},
+            assignment_type="open",
+            eligible_people=[],
+            current_assignee=None,
+        )
+        db.add(chore)
+        await db.commit()
+        await db.refresh(chore)
+
+        await skip_and_reassign_chore(chore, db, assignee=None, skipped_by="system")
+
+        logs = (await db.execute(select(ChoreLog))).scalars().all()
+        actions = [log.action for log in logs]
+        assert "skipped" in actions
+        assert "reassigned" not in actions
+
+
+class TestReassignChoreActor:
+    @pytest.mark.asyncio
+    async def test_reassign_logs_provided_person(self, db):
+        chore = _make_chore(
+            state="due",
+            assignment_type="rotating",
+            eligible_people=["Alice", "Bob"],
+            current_assignee="Alice",
+            rotation_index=0,
+        )
+        db.add(chore)
+        await db.commit()
+        await db.refresh(chore)
+
+        await reassign_chore(chore, db, assignee="Bob", person="derek")
+
+        logs = (await db.execute(select(ChoreLog))).scalars().all()
+        reassign_log = next(log for log in logs if log.action == "reassigned")
+        assert reassign_log.person == "derek"
+        assert reassign_log.reassigned_to == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_reassign_defaults_to_system(self, db):
+        chore = _make_chore(
+            state="due",
+            assignment_type="open",
+            current_assignee="Alice",
+        )
+        db.add(chore)
+        await db.commit()
+        await db.refresh(chore)
+
+        await reassign_chore(chore, db, assignee="Bob")
+
+        logs = (await db.execute(select(ChoreLog))).scalars().all()
+        reassign_log = next(log for log in logs if log.action == "reassigned")
+        assert reassign_log.person == "system"

--- a/frontend/src/__tests__/Log.test.jsx
+++ b/frontend/src/__tests__/Log.test.jsx
@@ -518,6 +518,62 @@ describe("Log", () => {
     });
   });
 
+  describe("Person log entries (UserLog unified view)", () => {
+    it("shows target type 'user' for entries whose chore_name starts with 'Person:'", async () => {
+      const personEntry = {
+        id: 99,
+        chore_id: 0,
+        chore_name: "Person: Alice",
+        person: "testuser",
+        action: "updated",
+        timestamp: "2026-04-20T12:00:00Z",
+        field_name: "goal_7d",
+        old_value: "20",
+        new_value: "30",
+      };
+      client.getLog.mockResolvedValue([personEntry]);
+      setViewportWidth(1024);
+      wrap(<Log />);
+
+      await waitFor(() => {
+        const userBadges = screen.getAllByText("user");
+        expect(userBadges.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("strips 'Person: ' prefix from chore_name for the Target cell", async () => {
+      const personEntry = {
+        id: 99,
+        chore_id: 0,
+        chore_name: "Person: Alice",
+        person: "testuser",
+        action: "updated",
+        timestamp: "2026-04-20T12:00:00Z",
+      };
+      client.getLog.mockResolvedValue([personEntry]);
+      setViewportWidth(1024);
+      wrap(<Log />);
+
+      await waitFor(() => {
+        // "Alice" should appear as the target name (without the "Person: " prefix)
+        expect(screen.getByText("Alice")).toBeInTheDocument();
+      });
+
+      // The raw "Person: Alice" string should not be visible as a cell value
+      expect(screen.queryByText("Person: Alice")).not.toBeInTheDocument();
+    });
+
+    it("shows target type 'chore' for entries whose chore_name does not start with 'Person:'", async () => {
+      setViewportWidth(1024);
+      wrap(<Log />);
+
+      await waitFor(() => {
+        const choreBadges = screen.getAllByText("chore");
+        expect(choreBadges.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
   describe("Responsive breakpoints (850px minimum for 5-column layout)", () => {
     afterEach(() => {
       setViewportWidth(1024); // Reset to desktop width


### PR DESCRIPTION
## Summary

- Add `UserLog` database table with full audit fields (person_id, person_name, action, field_name, old_value, new_value, changed_by, timestamp) and Alembic migration
- Extend `PUT /people/{id}` to log a `UserLog` entry for every changed field, including `goal_7d` and `goal_30d`
- Extend `GET /log` to return `ChoreLog` and `UserLog` entries in a unified, time-ordered response
- Fix `skip-reassign` to log the new `current_assignee` value (previously only the skip action was logged)
- Fix `reassign` to pass the requesting user as the actor instead of hard-coded `"system"`

## Test plan

- [ ] `PUT /people/{id}` with goal changes creates UserLog entries for each changed field
- [ ] `GET /log` returns combined ChoreLog and UserLog entries ordered by timestamp
- [ ] `POST /chores/{id}/skip-reassign` logs both the skip and the new assignee
- [ ] `POST /chores/{id}/reassign` logs the requesting user as the actor
- [ ] All existing tests continue to pass
- [ ] New tests cover goal-change logging, fixed skip-reassign log, and fixed reassign actor

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)