### PR TITLE
feat: Admin database management dashboard for PointsLog (#97)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .database import engine
 from .models import Base
-from .routers import auth, chores, people, points, log, config, theme, export, data_import, status
+from .routers import auth, chores, people, points, log, config, theme, export, data_import, status, admin_db
 from .services.scheduler import start_scheduler, stop_scheduler
 from .services.chore_service import transition_overdue_chores
 from .database import AsyncSessionLocal
@@ -61,6 +61,7 @@ app.include_router(theme.router)
 app.include_router(export.router)
 app.include_router(data_import.router)
 app.include_router(status.router)
+app.include_router(admin_db.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/admin_db.py
+++ b/backend/app/routers/admin_db.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..dependencies import require_admin
+from ..models import ChoreLog, Person, PointsLog
+from ..schemas import AdminDbPage, PointsLogAdminOut, PointsLogUpdate
+
+router = APIRouter(prefix="/admin/db", tags=["admin-db"])
+
+
+@router.get("/points-log", response_model=AdminDbPage)
+async def list_points_log(
+    limit: int = 20,
+    offset: int = 0,
+    current_admin: str = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Paginated list of PointsLog rows, newest first."""
+    total_result = await db.execute(select(func.count()).select_from(PointsLog))
+    total = total_result.scalar_one()
+
+    rows_result = await db.execute(
+        select(PointsLog)
+        .order_by(PointsLog.completed_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    items = rows_result.scalars().all()
+
+    return AdminDbPage(
+        items=[PointsLogAdminOut.model_validate(row) for row in items],
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
+
+
+@router.patch("/points-log/{entry_id}", response_model=PointsLogAdminOut)
+async def update_points_log(
+    entry_id: int,
+    body: PointsLogUpdate,
+    current_admin: str = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Edit points and/or person on a PointsLog row.
+
+    Computes the delta and applies it to Person.points.
+    Writes a ChoreLog audit entry.
+    """
+    row_result = await db.execute(select(PointsLog).where(PointsLog.id == entry_id))
+    row = row_result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="PointsLog entry not found")
+
+    old_points = row.points
+    old_person_name = row.person
+
+    # --- apply points delta to Person ---
+    delta = body.points - old_points
+    if delta != 0:
+        person_result = await db.execute(
+            select(Person).where(Person.name == old_person_name)
+        )
+        person_obj = person_result.scalar_one_or_none()
+        if person_obj is not None:
+            person_obj.points = max(0, person_obj.points + delta)
+
+    # If person name changed, rebalance both sides
+    if body.person != old_person_name:
+        # Remove old points from old person
+        old_person_result = await db.execute(
+            select(Person).where(Person.name == old_person_name)
+        )
+        old_person_obj = old_person_result.scalar_one_or_none()
+        if old_person_obj is not None:
+            old_person_obj.points = max(0, old_person_obj.points - old_points)
+
+        # Add new points to new person
+        new_person_result = await db.execute(
+            select(Person).where(Person.name == body.person)
+        )
+        new_person_obj = new_person_result.scalar_one_or_none()
+        if new_person_obj is not None:
+            new_person_obj.points = max(0, new_person_obj.points + body.points)
+
+    # --- audit log ---
+    changes = []
+    if old_points != body.points:
+        changes.append(f"points: {old_points} -> {body.points}")
+    if old_person_name != body.person:
+        changes.append(f"person: {old_person_name} -> {body.person}")
+
+    audit = ChoreLog(
+        chore_id=row.chore_id,
+        chore_name=f"PointsLog#{entry_id}",
+        person=current_admin,
+        action="admin_edit",
+        timestamp=datetime.now(timezone.utc),
+        field_name="points_log",
+        old_value=f"points={old_points}, person={old_person_name}",
+        new_value=f"points={body.points}, person={body.person}",
+    )
+    db.add(audit)
+
+    # --- update the row ---
+    row.points = body.points
+    row.person = body.person
+
+    await db.commit()
+    await db.refresh(row)
+    return PointsLogAdminOut.model_validate(row)
+
+
+@router.delete("/points-log/{entry_id}", status_code=204)
+async def delete_points_log(
+    entry_id: int,
+    current_admin: str = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a PointsLog row.
+
+    Reverses points on Person (floor at 0).
+    Writes a ChoreLog audit entry.
+    """
+    row_result = await db.execute(select(PointsLog).where(PointsLog.id == entry_id))
+    row = row_result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="PointsLog entry not found")
+
+    # Reverse points on person (floor at 0)
+    person_result = await db.execute(
+        select(Person).where(Person.name == row.person)
+    )
+    person_obj = person_result.scalar_one_or_none()
+    if person_obj is not None:
+        person_obj.points = max(0, person_obj.points - row.points)
+
+    # Audit log
+    audit = ChoreLog(
+        chore_id=row.chore_id,
+        chore_name=f"PointsLog#{entry_id}",
+        person=current_admin,
+        action="admin_delete",
+        timestamp=datetime.now(timezone.utc),
+        field_name="points_log",
+        old_value=f"points={row.points}, person={row.person}",
+        new_value=None,
+    )
+    db.add(audit)
+
+    await db.delete(row)
+    await db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -264,6 +264,24 @@ class UpdateCheckStatus(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# ── Admin DB ─────────────────────────────────────────────────────────────────
+
+class PointsLogUpdate(BaseModel):
+    points: int
+    person: str
+
+
+class PointsLogAdminOut(PointsLogOut):
+    pass
+
+
+class AdminDbPage(BaseModel):
+    items: list[PointsLogAdminOut]
+    total: int
+    offset: int
+    limit: int
+
+
 # ── Theme ────────────────────────────────────────────────────────────────────
 
 class ThemeColors(BaseModel):

--- a/backend/tests/test_admin_db.py
+++ b/backend/tests/test_admin_db.py
@@ -1,0 +1,314 @@
+"""Tests for admin_db router: CRUD, access control, audit logging, edge cases."""
+import pytest
+from datetime import datetime, timezone
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ChoreLog, Person, PointsLog, Settings
+from app.security import hash_password
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _make_admin(db: AsyncSession, username: str = "admin", password: str = "adminpass") -> Person:
+    db.add(Settings(key="auth_enabled", value="true"))
+    person = Person(
+        name="Admin",
+        username=username,
+        password_hash=hash_password(password),
+        is_admin=True,
+        points=0,
+    )
+    db.add(person)
+    await db.commit()
+    await db.refresh(person)
+    return person
+
+
+async def _make_normal_user(db: AsyncSession, username: str = "user", password: str = "userpass") -> Person:
+    person = Person(
+        name="User",
+        username=username,
+        password_hash=hash_password(password),
+        is_admin=False,
+        points=0,
+    )
+    db.add(person)
+    await db.commit()
+    await db.refresh(person)
+    return person
+
+
+async def _make_points_log(
+    db: AsyncSession,
+    person_name: str = "Alice",
+    points: int = 10,
+    chore_id: int = 1,
+) -> PointsLog:
+    row = PointsLog(
+        person=person_name,
+        points=points,
+        chore_id=chore_id,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def _token(client: AsyncClient, username: str, password: str) -> str:
+    r = await client.post("/auth/login", json={"username": username, "password": password})
+    return r.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: list (GET)
+# ---------------------------------------------------------------------------
+
+class TestListPointsLog:
+    @pytest.mark.asyncio
+    async def test_admin_can_list(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        await _make_points_log(db, person_name="Alice", points=5)
+        await _make_points_log(db, person_name="Bob", points=8)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.get("/admin/db/points-log", headers={"Authorization": f"Bearer {token}"})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 2
+        assert len(data["items"]) == 2
+        assert data["offset"] == 0
+        assert data["limit"] == 20
+
+    @pytest.mark.asyncio
+    async def test_non_admin_forbidden(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        await _make_normal_user(db)
+
+        token = await _token(client, "user", "userpass")
+        r = await client.get("/admin/db/points-log", headers={"Authorization": f"Bearer {token}"})
+
+        assert r.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_rejected(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        r = await client.get("/admin/db/points-log")
+        assert r.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_pagination_offset_and_limit(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        for i in range(5):
+            await _make_points_log(db, person_name="Alice", points=i + 1)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.get(
+            "/admin/db/points-log?limit=2&offset=1",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 5
+        assert len(data["items"]) == 2
+        assert data["limit"] == 2
+        assert data["offset"] == 1
+
+    @pytest.mark.asyncio
+    async def test_ordered_newest_first(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        row1 = await _make_points_log(db, points=1)
+        row2 = await _make_points_log(db, points=2)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.get("/admin/db/points-log", headers={"Authorization": f"Bearer {token}"})
+        items = r.json()["items"]
+        # Newest entry (row2) should be first
+        assert items[0]["id"] == row2.id
+        assert items[1]["id"] == row1.id
+
+
+# ---------------------------------------------------------------------------
+# Tests: update (PATCH)
+# ---------------------------------------------------------------------------
+
+class TestUpdatePointsLog:
+    @pytest.mark.asyncio
+    async def test_admin_can_update_points(self, client: AsyncClient, db: AsyncSession):
+        admin = await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=10)
+        db.add(person)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 7, "person": "Alice"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["points"] == 7
+
+        # Person points adjusted: 10 + (7-10) = 7
+        await db.refresh(person)
+        assert person.points == 7
+
+    @pytest.mark.asyncio
+    async def test_update_writes_audit_log(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        row = await _make_points_log(db, person_name="Alice", points=5)
+
+        token = await _token(client, "admin", "adminpass")
+        await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 3, "person": "Alice"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        from sqlalchemy import select
+        result = await db.execute(
+            select(ChoreLog).where(ChoreLog.action == "admin_edit")
+        )
+        audit = result.scalars().all()
+        assert len(audit) == 1
+        assert "points" in audit[0].old_value
+        assert audit[0].person == "admin"
+
+    @pytest.mark.asyncio
+    async def test_update_404_on_missing_row(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            "/admin/db/points-log/99999",
+            json={"points": 5, "person": "Nobody"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        await _make_normal_user(db)
+        row = await _make_points_log(db)
+
+        token = await _token(client, "user", "userpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 1, "person": "Alice"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: delete (DELETE)
+# ---------------------------------------------------------------------------
+
+class TestDeletePointsLog:
+    @pytest.mark.asyncio
+    async def test_admin_can_delete(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        Person(name="Alice", username="alice", password_hash="x", points=10)
+        person = Person(name="Alice", username="alice", password_hash="x", points=10)
+        db.add(person)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 204
+
+        # Row is gone
+        from sqlalchemy import select
+        result = await db.execute(select(PointsLog).where(PointsLog.id == row.id))
+        assert result.scalar_one_or_none() is None
+
+    @pytest.mark.asyncio
+    async def test_delete_reverses_points_on_person(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=15)
+        db.add(person)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        await db.refresh(person)
+        assert person.points == 5  # 15 - 10
+
+    @pytest.mark.asyncio
+    async def test_delete_floors_points_at_zero(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=3)
+        db.add(person)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        await db.refresh(person)
+        assert person.points == 0  # Never goes negative
+
+    @pytest.mark.asyncio
+    async def test_delete_writes_audit_log(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        row = await _make_points_log(db, person_name="Alice", points=5)
+
+        token = await _token(client, "admin", "adminpass")
+        await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        from sqlalchemy import select
+        result = await db.execute(
+            select(ChoreLog).where(ChoreLog.action == "admin_delete")
+        )
+        audit = result.scalars().all()
+        assert len(audit) == 1
+        assert audit[0].person == "admin"
+
+    @pytest.mark.asyncio
+    async def test_delete_404_on_missing_row(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        token = await _token(client, "admin", "adminpass")
+        r = await client.delete(
+            "/admin/db/points-log/99999",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_delete(self, client: AsyncClient, db: AsyncSession):
+        await _make_admin(db)
+        await _make_normal_user(db)
+        row = await _make_points_log(db)
+
+        token = await _token(client, "user", "userpass")
+        r = await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import SettingsAuth from "./pages/SettingsAuth";
 import SettingsChores from "./pages/SettingsChores";
 import SettingsTheme from "./pages/SettingsTheme";
 import SettingsData from "./pages/SettingsData";
+import SettingsDataPointsLog from "./pages/SettingsDataPointsLog";
 import SettingsAbout from "./pages/SettingsAbout";
 import UserDetail from "./pages/UserDetail";
 import UserAvatarMenu from "./components/UserAvatarMenu";
@@ -158,6 +159,7 @@ function AppContent() {
               <Route path="chores" element={<SettingsChores />} />
               <Route path="theme" element={<SettingsTheme />} />
               <Route path="data" element={<SettingsData />} />
+              <Route path="data/pointslog" element={<SettingsDataPointsLog />} />
               <Route path="about" element={<SettingsAbout />} />
             </Route>
             <Route path="/admin" element={<Navigate to="/settings/general" replace />} />

--- a/frontend/src/__tests__/DatabaseSection.test.jsx
+++ b/frontend/src/__tests__/DatabaseSection.test.jsx
@@ -1,0 +1,271 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DatabaseSection from "../components/DatabaseSection";
+import * as client from "../api/client";
+
+vi.mock("../api/client");
+
+const SAMPLE_PAGE = {
+  items: [
+    { id: 1, person: "alice", points: 10, chore_id: 2, completed_at: "2024-01-15T10:00:00Z" },
+    { id: 2, person: "bob", points: 5, chore_id: 3, completed_at: "2024-01-14T09:00:00Z" },
+  ],
+  total: 2,
+  offset: 0,
+  limit: 20,
+};
+
+const PEOPLE = [
+  { id: 1, name: "Alice", username: "alice" },
+  { id: 2, name: "Bob", username: "bob" },
+];
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DatabaseSection />
+    </QueryClientProvider>
+  );
+}
+
+describe("DatabaseSection", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    client.getPeople.mockResolvedValue(PEOPLE);
+  });
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  it("renders the Points Log heading", () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    expect(screen.getByText("Points Log")).toBeInTheDocument();
+  });
+
+  it("shows column headers", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText("ID")).toBeInTheDocument();
+      expect(screen.getByText("Person")).toBeInTheDocument();
+      expect(screen.getByText("Points")).toBeInTheDocument();
+      expect(screen.getByText("Chore ID")).toBeInTheDocument();
+      expect(screen.getByText("Completed At")).toBeInTheDocument();
+      expect(screen.getByText("Actions")).toBeInTheDocument();
+    });
+  });
+
+  it("renders rows from API response", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeInTheDocument();
+      expect(screen.getByText("bob")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'No entries found' when list is empty", async () => {
+    client.getAdminPointsLog.mockResolvedValue({ items: [], total: 0, offset: 0, limit: 20 });
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText(/no entries found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when query fails", async () => {
+    client.getAdminPointsLog.mockRejectedValue(new Error("network error"));
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load points log/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Pagination ───────────────────────────────────────────────────────────
+
+  it("disables Previous button on first page", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => {
+      const prev = screen.getByText("Previous");
+      expect(prev).toBeDisabled();
+    });
+  });
+
+  it("disables Next button when on last page", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE); // total=2, limit=20
+    wrap();
+    await waitFor(() => {
+      const next = screen.getByText("Next");
+      expect(next).toBeDisabled();
+    });
+  });
+
+  it("enables Next when more pages exist", async () => {
+    client.getAdminPointsLog.mockResolvedValue({
+      ...SAMPLE_PAGE,
+      total: 25,
+    });
+    wrap();
+    await waitFor(() => {
+      const next = screen.getByText("Next");
+      expect(next).not.toBeDisabled();
+    });
+  });
+
+  it("shows pagination count info", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText(/showing 1.+2 of 2/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Inline edit ──────────────────────────────────────────────────────────
+
+  it("enters edit mode when Edit button is clicked", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    const editBtns = screen.getAllByText("Edit");
+    fireEvent.click(editBtns[0]);
+
+    expect(screen.getByLabelText("Edit person")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit points")).toBeInTheDocument();
+  });
+
+  it("renders person field as a select (not input) in edit mode", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+
+    await waitFor(() => {
+      const personField = screen.getByLabelText("Edit person");
+      expect(personField.tagName).toBe("SELECT");
+      expect(screen.queryByRole("textbox", { name: /edit person/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("person select is populated with people from API", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+
+    await waitFor(() => {
+      const select = screen.getByLabelText("Edit person");
+      const options = Array.from(select.options);
+      expect(options.map((o) => o.value)).toContain("alice");
+      expect(options.map((o) => o.value)).toContain("bob");
+      expect(options.map((o) => o.text)).toContain("Alice");
+      expect(options.map((o) => o.text)).toContain("Bob");
+    });
+  });
+
+  it("pre-populates edit fields with current values", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Edit person").value).toBe("alice");
+      expect(screen.getByLabelText("Edit points").value).toBe("10");
+    });
+  });
+
+  it("cancels edit mode when Cancel is clicked", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.queryByLabelText("Edit person")).not.toBeInTheDocument();
+  });
+
+  it("calls updateAdminPointsLog with new values on save", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    client.updateAdminPointsLog.mockResolvedValue({ ...SAMPLE_PAGE.items[0], points: 7 });
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+
+    const pointsInput = screen.getByLabelText("Edit points");
+    fireEvent.change(pointsInput, { target: { value: "7" } });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(client.updateAdminPointsLog).toHaveBeenCalledWith(1, { points: 7, person: "alice" });
+    });
+  });
+
+  it("shows error if points field is not a number on save", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Edit")[0]);
+    const pointsInput = screen.getByLabelText("Edit points");
+    fireEvent.change(pointsInput, { target: { value: "abc" } });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(screen.getByText(/points must be a valid integer/i)).toBeInTheDocument();
+  });
+
+  // ── Delete / Modal ───────────────────────────────────────────────────────
+
+  it("opens confirm modal when Delete is clicked", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Delete")[0]);
+
+    expect(screen.getByText("Confirm Delete")).toBeInTheDocument();
+    expect(screen.getByText(/delete pointslog entry #1/i)).toBeInTheDocument();
+  });
+
+  it("closes modal when Cancel is clicked in delete dialog", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Delete")[0]);
+    // Modal has two Cancel buttons (one inside modal actions)
+    const cancelBtns = screen.getAllByText("Cancel");
+    // click the one in the modal actions area (last one)
+    fireEvent.click(cancelBtns[cancelBtns.length - 1]);
+
+    expect(screen.queryByText("Confirm Delete")).not.toBeInTheDocument();
+  });
+
+  it("calls deleteAdminPointsLog when confirmed", async () => {
+    client.getAdminPointsLog.mockResolvedValue(SAMPLE_PAGE);
+    client.deleteAdminPointsLog.mockResolvedValue(null);
+    wrap();
+    await waitFor(() => screen.getByText("alice"));
+
+    fireEvent.click(screen.getAllByText("Delete")[0]);
+
+    // click the delete confirm button inside modal
+    const deleteBtns = screen.getAllByText("Delete");
+    // last Delete button is the confirm one inside the modal
+    fireEvent.click(deleteBtns[deleteBtns.length - 1]);
+
+    await waitFor(() => {
+      expect(client.deleteAdminPointsLog).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/frontend/src/__tests__/SettingsData.test.jsx
+++ b/frontend/src/__tests__/SettingsData.test.jsx
@@ -66,4 +66,30 @@ describe("SettingsData", () => {
       expect(input.value).toBe("30");
     });
   });
+
+  it("renders the Data Management section heading", () => {
+    wrap();
+    expect(screen.getByText("Data Management")).toBeInTheDocument();
+  });
+
+  it("renders the Data Management section description", () => {
+    wrap();
+    expect(
+      screen.getByText(/directly modify or remove records in specific database tables/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Points Log link in the Data Management section", () => {
+    wrap();
+    const link = screen.getByRole("link", { name: /points log/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/settings/data/pointslog");
+  });
+
+  it("renders the Points Log entry description inline", () => {
+    wrap();
+    expect(
+      screen.getByText(/modify or remove records for recently completed chores/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/SettingsDataPointsLog.test.jsx
+++ b/frontend/src/__tests__/SettingsDataPointsLog.test.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import SettingsDataPointsLog from "../pages/SettingsDataPointsLog";
+import * as client from "../api/client";
+
+vi.mock("../api/client");
+vi.mock("../contexts/AuthContext", () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => ({ user: { username: "admin", is_admin: true }, logout: vi.fn() }),
+}));
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <SettingsDataPointsLog />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("SettingsDataPointsLog", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    client.getAdminPointsLog.mockResolvedValue({ items: [], total: 0, offset: 0, limit: 20 });
+  });
+
+  it("renders the Points Log section heading", () => {
+    wrap();
+    expect(screen.getByText("Points Log")).toBeInTheDocument();
+  });
+
+  it("renders the DatabaseSection table headers", async () => {
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText("ID")).toBeInTheDocument();
+      expect(screen.getByText("Person")).toBeInTheDocument();
+      expect(screen.getByText("Points")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'No entries found' when there are no log entries", async () => {
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText(/no entries found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders rows when the API returns entries", async () => {
+    client.getAdminPointsLog.mockResolvedValue({
+      items: [
+        { id: 1, person: "Alice", points: 10, chore_id: 2, completed_at: "2024-01-15T10:00:00Z" },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 20,
+    });
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -120,6 +120,19 @@ export const changePassword = (oldPassword, newPassword) =>
 export const redeemPoints = (personId, amount) =>
   request("POST", `/people/${personId}/redeem`, { amount });
 
+// Admin DB
+export const getAdminPointsLog = (params = {}) => {
+  const query = new URLSearchParams();
+  if (params.limit !== undefined) query.append("limit", params.limit);
+  if (params.offset !== undefined) query.append("offset", params.offset);
+  const qs = query.toString();
+  return request("GET", `/admin/db/points-log${qs ? `?${qs}` : ""}`);
+};
+export const updateAdminPointsLog = (id, data) =>
+  request("PATCH", `/admin/db/points-log/${id}`, data);
+export const deleteAdminPointsLog = (id) =>
+  request("DELETE", `/admin/db/points-log/${id}`);
+
 // Export/Import
 export const exportConfig = () => request("GET", "/export/config");
 

--- a/frontend/src/components/DatabaseSection.jsx
+++ b/frontend/src/components/DatabaseSection.jsx
@@ -1,0 +1,280 @@
+import React, { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getAdminPointsLog,
+  updateAdminPointsLog,
+  deleteAdminPointsLog,
+  getPeople,
+} from "../api/client";
+import Modal from "./Modal";
+import "../pages/Settings.css";
+
+const PAGE_SIZE = 20;
+
+export default function DatabaseSection() {
+  const queryClient = useQueryClient();
+  const [offset, setOffset] = useState(0);
+  const [editId, setEditId] = useState(null);
+  const [editPoints, setEditPoints] = useState("");
+  const [editPerson, setEditPerson] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["admin-points-log", offset],
+    queryFn: () => getAdminPointsLog({ limit: PAGE_SIZE, offset }),
+  });
+
+  const { data: people = [], isLoading: isPeopleLoading } = useQuery({
+    queryKey: ["people"],
+    queryFn: getPeople,
+  });
+
+  const total = data?.total ?? 0;
+  const items = data?.items ?? [];
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, points, person }) =>
+      updateAdminPointsLog(id, { points: Number(points), person }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-points-log"] });
+      setEditId(null);
+      setSuccess("Entry updated.");
+      setError(null);
+      setTimeout(() => setSuccess(null), 3000);
+    },
+    onError: (err) => {
+      setError(err.message || "Failed to update entry.");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id) => deleteAdminPointsLog(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-points-log"] });
+      setDeleteTarget(null);
+      setSuccess("Entry deleted.");
+      setError(null);
+      setTimeout(() => setSuccess(null), 3000);
+    },
+    onError: (err) => {
+      setError(err.message || "Failed to delete entry.");
+    },
+  });
+
+  function startEdit(item) {
+    setEditId(item.id);
+    setEditPoints(String(item.points));
+    setEditPerson(item.person);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditId(null);
+    setError(null);
+  }
+
+  function saveEdit(id) {
+    const pts = parseInt(editPoints, 10);
+    if (isNaN(pts)) {
+      setError("Points must be a valid integer.");
+      return;
+    }
+    if (!editPerson.trim()) {
+      setError("Person cannot be empty.");
+      return;
+    }
+    updateMutation.mutate({ id, points: pts, person: editPerson.trim() });
+  }
+
+  function confirmDelete(item) {
+    setDeleteTarget(item);
+    setError(null);
+  }
+
+  function doDelete() {
+    if (deleteTarget) {
+      deleteMutation.mutate(deleteTarget.id);
+    }
+  }
+
+  return (
+    <section className="settings-section">
+      <div className="section-row">
+        <h3>Points Log</h3>
+      </div>
+      <hr />
+
+      {error && <div className="error-message">{error}</div>}
+      {success && <div className="success-message">{success}</div>}
+
+      {isLoading && <div className="loading">Loading&hellip;</div>}
+      {isError && <div className="error-message">Failed to load points log.</div>}
+
+      {!isLoading && !isError && (
+        <>
+          <div className="db-table-wrapper">
+            <table className="db-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Person</th>
+                  <th>Points</th>
+                  <th>Chore ID</th>
+                  <th>Completed At</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} style={{ textAlign: "center", color: "var(--text-muted)" }}>
+                      No entries found.
+                    </td>
+                  </tr>
+                ) : (
+                  items.map((item) =>
+                    editId === item.id ? (
+                      <tr key={item.id}>
+                        <td>{item.id}</td>
+                        <td>
+                          <select
+                            className="db-edit-input"
+                            value={editPerson}
+                            onChange={(e) => setEditPerson(e.target.value)}
+                            aria-label="Edit person"
+                            disabled={updateMutation.isPending || isPeopleLoading}
+                          >
+                            {isPeopleLoading ? (
+                              <option value={editPerson}>{editPerson}</option>
+                            ) : (
+                              people.map((p) => (
+                                <option key={p.id} value={p.username}>
+                                  {p.name}
+                                </option>
+                              ))
+                            )}
+                          </select>
+                        </td>
+                        <td>
+                          <input
+                            className="db-edit-input db-edit-input--narrow"
+                            type="number"
+                            value={editPoints}
+                            onChange={(e) => setEditPoints(e.target.value)}
+                            aria-label="Edit points"
+                            disabled={updateMutation.isPending}
+                          />
+                        </td>
+                        <td>{item.chore_id}</td>
+                        <td>{new Date(item.completed_at).toLocaleString()}</td>
+                        <td className="db-actions">
+                          <button
+                            className="btn-primary"
+                            onClick={() => saveEdit(item.id)}
+                            disabled={updateMutation.isPending}
+                          >
+                            {updateMutation.isPending ? "Saving…" : "Save"}
+                          </button>
+                          <button
+                            className="btn-secondary"
+                            onClick={cancelEdit}
+                            disabled={updateMutation.isPending}
+                          >
+                            Cancel
+                          </button>
+                        </td>
+                      </tr>
+                    ) : (
+                      <tr key={item.id}>
+                        <td>{item.id}</td>
+                        <td>{item.person}</td>
+                        <td>{item.points}</td>
+                        <td>{item.chore_id}</td>
+                        <td>{new Date(item.completed_at).toLocaleString()}</td>
+                        <td className="db-actions">
+                          <button
+                            className="btn-secondary"
+                            onClick={() => startEdit(item)}
+                            aria-label={`Edit entry ${item.id}`}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            className="btn-danger"
+                            onClick={() => confirmDelete(item)}
+                            aria-label={`Delete entry ${item.id}`}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  )
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="db-pagination">
+            <span className="db-pagination-info">
+              {total === 0
+                ? "No entries"
+                : `Showing ${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} of ${total}`}
+            </span>
+            <div className="db-pagination-controls">
+              <button
+                className="btn-secondary"
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                disabled={!hasPrev}
+              >
+                Previous
+              </button>
+              <button
+                className="btn-secondary"
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                disabled={!hasNext}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {deleteTarget && (
+        <Modal
+          title="Confirm Delete"
+          onClose={() => setDeleteTarget(null)}
+        >
+          <p>
+            Delete PointsLog entry #{deleteTarget.id} ({deleteTarget.person},{" "}
+            {deleteTarget.points} pts)?
+          </p>
+          <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+            This will reverse the points on the person (floored at 0) and cannot be undone.
+          </p>
+          <div className="db-modal-actions">
+            <button
+              className="btn-danger"
+              onClick={doDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete"}
+            </button>
+            <button
+              className="btn-secondary"
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleteMutation.isPending}
+            >
+              Cancel
+            </button>
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -139,3 +139,87 @@
   flex-direction: column;
   gap: 0.5rem;
 }
+
+/* ── Data Management entries ─────────────────────────────────────────────── */
+
+.data-management-entry {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+/* ── DatabaseSection ─────────────────────────────────────────────────────── */
+
+.db-table-wrapper {
+  overflow-x: auto;
+}
+
+.db-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.db-table th,
+.db-table td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.db-table th {
+  background: var(--surface2);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.db-table tr:nth-child(even) td {
+  background: var(--surface);
+}
+
+.db-edit-input {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.db-edit-input--narrow {
+  max-width: 80px;
+}
+
+.db-actions {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.db-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.db-pagination-info {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.db-pagination-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.db-modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}

--- a/frontend/src/pages/SettingsData.jsx
+++ b/frontend/src/pages/SettingsData.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import { getLogRetention, setLogRetention } from "../api/client";
 import ExportImport from "../components/ExportImport";
 import "./Settings.css";
@@ -91,6 +92,22 @@ export default function SettingsData() {
             </div>
           </div>
         )}
+      </section>
+
+      <section className="settings-section">
+        <div className="section-row">
+          <h3>Data Management</h3>
+        </div>
+        <hr />
+        <div className="section-content">
+          <p className="setting-description">
+            Directly modify or remove records in specific database tables.
+          </p>
+          <div className="data-management-entry">
+            <Link to="/settings/data/pointslog">Points Log</Link>
+            {" — Modify or remove records for recently completed chores."}
+          </div>
+        </div>
       </section>
     </div>
   );

--- a/frontend/src/pages/SettingsDataPointsLog.jsx
+++ b/frontend/src/pages/SettingsDataPointsLog.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import DatabaseSection from "../components/DatabaseSection";
+import "./Settings.css";
+import "./AdminPanel.css";
+
+export default function SettingsDataPointsLog() {
+  return (
+    <div className="settings-page">
+      <DatabaseSection />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an admin-only **Data Management** section to Settings > Data with a PointsLog editor at `/settings/data/pointslog`
- New backend router (`/admin/db/points-log`) supports paginated list, inline cell edit (points + person), and row delete — all gated to admin role and logged to the audit trail
- `DatabaseSection` reusable component provides the paginated table UI with inline editing and a delete confirmation modal
- Full test coverage: backend pytest suite, and frontend tests for `DatabaseSection`, `SettingsData`, and `SettingsDataPointsLog`

## Test plan

- [ ] Log in as a non-admin user and confirm `/settings/data/pointslog` is not accessible
- [ ] Log in as admin, navigate Settings > Data, verify "Data Management" section with Points Log link appears
- [ ] Open Points Log page, verify entries load with correct person, points, chore, and date columns
- [ ] Edit a points value inline and save; confirm the updated value persists on reload
- [ ] Edit a person value inline and save; confirm the updated value persists on reload
- [ ] Click cancel on an in-progress edit; confirm original values are restored
- [ ] Delete a row and confirm it disappears after the confirmation modal
- [ ] Verify pagination controls (prev/next, page info) work correctly with >25 entries
- [ ] Run `pytest backend/tests/test_admin_db.py` — all tests pass
- [ ] Run `npm test` in frontend — all new tests pass

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)