### PR TITLE
fix: correct points window filtering and dashboard lookup key (#208)

### DIFF
--- a/backend/app/routers/points.py
+++ b/backend/app/routers/points.py
@@ -12,6 +12,11 @@ from ..dependencies import get_current_user
 router = APIRouter(prefix="/points", tags=["points"])
 
 
+def _as_aware(dt: datetime) -> datetime:
+    """Return dt as timezone-aware; assumes UTC if naive."""
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
 @router.get("", response_model=list[LeaderboardEntry])
 async def leaderboard(current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     result = await db.execute(
@@ -36,9 +41,6 @@ async def points_summary(current_user: str = Depends(get_current_user), db: Asyn
         select(PointsLog).where(PointsLog.completed_at >= cutoff_30d)
     )
     logs = log_result.scalars().all()
-
-    def _as_aware(dt: datetime) -> datetime:
-        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
     totals: dict[str, dict] = {p: {"points_7d": 0, "points_30d": 0} for p in people}
     for log in logs:
@@ -66,8 +68,8 @@ async def user_stats(person: str, current_user: str = Depends(get_current_user),
     logs = result.scalars().all()
 
     total_points = sum(log.points for log in logs)
-    points_7d = sum(log.points for log in logs if log.completed_at >= cutoff_7d)
-    points_30d = sum(log.points for log in logs if log.completed_at >= cutoff_30d)
+    points_7d = sum(log.points for log in logs if _as_aware(log.completed_at) >= cutoff_7d)
+    points_30d = sum(log.points for log in logs if _as_aware(log.completed_at) >= cutoff_30d)
 
     log_result = await db.execute(
         select(ChoreLog).where(ChoreLog.person == person)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -676,6 +676,77 @@ class TestPointsAPI:
         assert bob["points_30d"] == 0
 
     @pytest.mark.asyncio
+    async def test_user_stats_returns_nonzero_after_completion(self, authenticated_client):
+        """user_stats should return correct non-zero points_7d and points_30d."""
+        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+
+        r = await authenticated_client.get("/points/stats/testuser")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["points_7d"] == 5
+        assert data["points_30d"] == 5
+        assert data["total_points"] == 5
+        assert data["display_points"] == 5
+
+    @pytest.mark.asyncio
+    async def test_user_stats_excludes_old_entries(self, authenticated_client, db):
+        """user_stats should exclude PointsLog entries older than the time window."""
+        from datetime import datetime, timedelta, timezone
+        from app.models import PointsLog
+
+        # Insert a PointsLog entry with completed_at 40 days ago (outside both windows)
+        old_entry = PointsLog(
+            person="testuser",
+            chore_id=0,
+            points=99,
+            completed_at=datetime.now(timezone.utc) - timedelta(days=40),
+        )
+        db.add(old_entry)
+        await db.commit()
+
+        r = await authenticated_client.get("/points/stats/testuser")
+        assert r.status_code == 200
+        data = r.json()
+        # Old entry should not appear in 7d or 30d windows
+        assert data["points_7d"] == 0
+        assert data["points_30d"] == 0
+        # But total should include it
+        assert data["total_points"] == 99
+
+    @pytest.mark.asyncio
+    async def test_user_stats_correct_totals_across_windows(self, authenticated_client, db):
+        """user_stats should correctly bucket points into 7d vs 30d windows."""
+        from datetime import datetime, timedelta, timezone
+        from app.models import PointsLog
+
+        # Entry within 7 days (also within 30 days)
+        recent = PointsLog(
+            person="testuser",
+            chore_id=0,
+            points=10,
+            completed_at=datetime.now(timezone.utc) - timedelta(days=3),
+        )
+        # Entry within 30 days but outside 7 days
+        older = PointsLog(
+            person="testuser",
+            chore_id=0,
+            points=20,
+            completed_at=datetime.now(timezone.utc) - timedelta(days=15),
+        )
+        db.add_all([recent, older])
+        await db.commit()
+
+        r = await authenticated_client.get("/points/stats/testuser")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["points_7d"] == 10
+        assert data["points_30d"] == 30
+        assert data["total_points"] == 30
+
+    @pytest.mark.asyncio
     async def test_health(self, authenticated_client):
         r = await authenticated_client.get("/health")
         assert r.status_code == 200

--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -10,7 +10,7 @@ vi.mock("../api/client");
 
 const TODAY = new Date().toISOString().split("T")[0];
 
-const PEOPLE = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }];
+const PEOPLE = [{ id: 1, name: "Alice", username: "alice" }, { id: 2, name: "Bob", username: "bob" }];
 
 const CHORES = [
   {
@@ -40,8 +40,8 @@ const CHORES = [
 ];
 
 const SUMMARY = [
-  { person: "Alice", points_7d: 10, points_30d: 25 },
-  { person: "Bob", points_7d: 0, points_30d: 5 },
+  { person: "alice", points_7d: 10, points_30d: 25 },
+  { person: "bob", points_7d: 0, points_30d: 5 },
 ];
 
 function wrap(ui) {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -52,7 +52,7 @@ export default function Dashboard() {
               person={person}
               chores={chores}
               people={people}
-              summary={summaryByPerson[person.name]}
+              summary={summaryByPerson[person.username]}
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary

Two related bugs caused all users to show 0 points on the Dashboard:

- **Backend — timezone-aware comparison (#208):** `user_stats` compared naive `completed_at` datetimes from the database against timezone-aware cutoffs (`datetime.now(timezone.utc) - timedelta(...)`). Python raises no error but the comparison always evaluates as outside the window, so `points_7d` and `points_30d` always returned 0. The fix promotes `_as_aware()` to module level and applies it inside `user_stats` so naive UTC timestamps are handled correctly.

- **Frontend — wrong lookup key (#208):** `Dashboard.jsx` was keying the summary map with `person.name` (display name), but `/points/summary` keys its response by `person.username`. Any user whose display name differs from their username always received `undefined` (rendered as 0 points). The fix switches the lookup to `person.username`.

## Changes

| File | Change |
|---|---|
| `backend/app/routers/points.py` | Promote `_as_aware` to module scope; apply it in `user_stats` cutoff comparisons |
| `backend/tests/test_api.py` | Three new tests covering the 7d/30d window logic and non-zero stats after completion |
| `frontend/src/pages/Dashboard.jsx` | Look up summary by `person.username` instead of `person.name` |

## Test plan

- [ ] `pytest backend/tests/test_api.py` passes, including the three new `TestPointsAPI` tests
- [ ] Dashboard shows correct non-zero points for users whose display name differs from their username
- [ ] Dashboard continues to show correct points for users whose display name matches their username

Closes #208