### PR TITLE
feat: Add chore summary stats tiles to /chores page (#81)

### DIFF
--- a/frontend/src/components/ThemeSettings.css
+++ b/frontend/src/components/ThemeSettings.css
@@ -90,7 +90,7 @@
   display: flex;
 }
 
-.action-btn {
+.theme-actions .action-btn {
   width: 32px;
   height: 32px;
   padding: 0;
@@ -105,31 +105,31 @@
   font-size: 0;
 }
 
-.action-btn .material-icons {
+.theme-actions .action-btn .material-icons {
   font-size: 20px;
 }
 
-.action-btn:hover {
+.theme-actions .action-btn:hover {
   background-color: var(--surface);
 }
 
-.action-btn.edit-btn {
+.theme-actions .action-btn.edit-btn {
   color: var(--primary);
 }
 
-.action-btn.copy-btn {
+.theme-actions .action-btn.copy-btn {
   color: var(--secondary);
 }
 
-.action-btn.rename-btn {
+.theme-actions .action-btn.rename-btn {
   color: var(--accent);
 }
 
-.action-btn.delete-btn {
+.theme-actions .action-btn.delete-btn {
   color: var(--error);
 }
 
-.action-btn:disabled {
+.theme-actions .action-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -299,9 +299,8 @@
     max-width: 100%;
   }
 
-  .action-btn {
+  .theme-actions .action-btn {
     width: 28px;
     height: 28px;
-    font-size: 0.9rem;
   }
 }

--- a/frontend/src/pages/Chores.css
+++ b/frontend/src/pages/Chores.css
@@ -279,3 +279,37 @@
 .MuiPopover-paper.MuiMenu-paper .MuiMenuItem-root.Mui-selected:hover {
   background-color: var(--accent-bg) !important;
 }
+
+.chore-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.chore-stat-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.chore-stat-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.chore-stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .chore-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -4,7 +4,7 @@ import { useSearchParams } from "react-router-dom";
 import { MdFilterList, MdAdd } from "react-icons/md";
 import { Select, MenuItem, Chip, Box } from "@mui/material";
 import { useAuth } from "../contexts/AuthContext";
-import { getChores, getPeople, createChore, updateChore, deleteChore, completeChore, skipChore, markDueChore } from "../api/client";
+import { getChores, getPeople, createChore, updateChore, deleteChore, completeChore, skipChore, markDueChore, getPointsSummary } from "../api/client";
 import ChoreForm from "../components/ChoreForm";
 import ChoreList from "../components/ChoreList";
 import Modal from "../components/Modal";
@@ -94,6 +94,10 @@ export default function Manage() {
     queryFn: getPeople,
   });
 
+  const { data: pointsSummary = [] } = useQuery({
+    queryKey: ["points-summary"],
+    queryFn: getPointsSummary,
+  });
 
   const invalidate = () => qc.invalidateQueries({ queryKey: ["chores"] });
 
@@ -186,6 +190,28 @@ export default function Manage() {
   const assignees = [...new Set(chores.map(getChoreAssigneeName).filter(Boolean))].sort();
   const states = [...new Set(chores.map(c => c.state))].sort();
 
+  const summaryStats = useMemo(() => {
+    const totalChores = chores.filter(c => !c.disabled).length;
+    const totalPoints = chores.filter(c => !c.disabled).reduce((sum, c) => sum + (c.points || 0), 0);
+    const points7d = pointsSummary.reduce((sum, p) => sum + (p.points_7d || 0), 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const cutoff = new Date(today);
+    cutoff.setDate(cutoff.getDate() + 7);
+
+    const pointsDueNext7 = chores
+      .filter(c => !c.disabled && c.next_due)
+      .filter(c => {
+        const d = new Date(c.next_due);
+        d.setHours(0, 0, 0, 0);
+        return d >= today && d <= cutoff;
+      })
+      .reduce((sum, c) => sum + (c.points || 0), 0);
+
+    return { totalChores, totalPoints, points7d, pointsDueNext7 };
+  }, [chores, pointsSummary]);
+
   return (
     <div className="manage-page">
       <div className="page-header">
@@ -199,6 +225,25 @@ export default function Manage() {
             <MdAdd className="action-icon" />
             <span className="action-text">Add Chore</span>
           </button>
+        </div>
+      </div>
+
+      <div className="chore-stats-grid">
+        <div className="chore-stat-card">
+          <div className="chore-stat-label">Chores</div>
+          <div className="chore-stat-value">{summaryStats.totalChores}</div>
+        </div>
+        <div className="chore-stat-card">
+          <div className="chore-stat-label">Total Points</div>
+          <div className="chore-stat-value">{summaryStats.totalPoints}</div>
+        </div>
+        <div className="chore-stat-card">
+          <div className="chore-stat-label">Completed Last 7 Days</div>
+          <div className="chore-stat-value">{summaryStats.points7d}</div>
+        </div>
+        <div className="chore-stat-card">
+          <div className="chore-stat-label">Due Next 7 Days</div>
+          <div className="chore-stat-value">{summaryStats.pointsDueNext7}</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Add 4 stat tiles at the top of `/chores` page: Chores, Total Points, Completed Last 7 Days, Due Next 7 Days
- Stats computed client-side from existing `getChores()` and `getPointsSummary()` queries — no backend changes
- Fix `ThemeSettings.css` global `.action-btn` class pollution: `font-size: 0` from icon button styles was bleeding into ChoreCard text buttons, making action buttons invisible (introduced in #219)

## Test plan

- [ ] Visit `/chores` — verify 4 stat tiles render with correct values
- [ ] Expand a chore card — verify Complete/Skip/Edit/Delete buttons are visible with text
- [ ] Visit Settings > Themes — verify theme action icon buttons still work (edit/copy/rename/delete)
- [ ] Verify tile counts update after completing or adding a chore

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)