### PR TITLE
feat: Add hex color input and color picker to theme editor (#113)

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/frontend/src/__tests__/ThemeSettings.test.jsx
+++ b/frontend/src/__tests__/ThemeSettings.test.jsx
@@ -313,4 +313,114 @@ describe("ThemeSettings", () => {
     const editBtn = customCard.querySelector('[aria-label="Edit My Custom Theme"]');
     expect(editBtn).toBeInTheDocument();
   });
+
+  it("hex text input updates color picker on valid hex", async () => {
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/^accent$/i));
+
+    const hexInput = screen.getByLabelText(/^accent$/i);
+    fireEvent.change(hexInput, { target: { value: "#ff0000" } });
+
+    await waitFor(() => {
+      const picker = screen.getByLabelText(/accent picker/i);
+      expect(picker).toHaveValue("#ff0000");
+    });
+  });
+
+  it("color picker updates hex text input", async () => {
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/accent picker/i));
+
+    const picker = screen.getByLabelText(/accent picker/i);
+    fireEvent.change(picker, { target: { value: "#00ff00" } });
+
+    await waitFor(() => {
+      const hexInput = screen.getByLabelText(/^accent$/i);
+      expect(hexInput).toHaveValue("#00ff00");
+    });
+  });
+
+  it("incomplete hex does not update color state", async () => {
+    client.saveTheme.mockResolvedValue({ id: "custom", name: "Dark Custom", colors: THEMES[0].colors });
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/^accent$/i));
+
+    fireEvent.change(screen.getByLabelText(/^accent$/i), { target: { value: "#abc" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save.*theme/i }));
+
+    await waitFor(() => {
+      expect(client.saveTheme).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colors: expect.objectContaining({ accent: THEMES[0].colors.accent }),
+        })
+      );
+    });
+  });
+
+  it("invalid hex chars do not update color state", async () => {
+    client.saveTheme.mockResolvedValue({ id: "custom", name: "Dark Custom", colors: THEMES[0].colors });
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/^accent$/i));
+
+    fireEvent.change(screen.getByLabelText(/^accent$/i), { target: { value: "#gg0000" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save.*theme/i }));
+
+    await waitFor(() => {
+      expect(client.saveTheme).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colors: expect.objectContaining({ accent: THEMES[0].colors.accent }),
+        })
+      );
+    });
+  });
+
+  it("hex input normalizes missing # prefix", async () => {
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/^accent$/i));
+
+    const hexInput = screen.getByLabelText(/^accent$/i);
+    fireEvent.change(hexInput, { target: { value: "ff0000" } });
+
+    await waitFor(() => {
+      expect(hexInput).toHaveValue("#ff0000");
+    });
+  });
+
+  it("saved theme uses hex-typed value same as picker-chosen value", async () => {
+    client.saveTheme.mockResolvedValue({ id: "custom", name: "Dark Custom", colors: THEMES[0].colors });
+    wrap(<ThemeSettings />);
+    await waitFor(() => screen.getByText("Dark"));
+
+    fireEvent.click(screen.getByRole("button", { name: /customize.*current/i }));
+    await waitFor(() => screen.getByLabelText(/^accent$/i));
+
+    fireEvent.change(screen.getByLabelText(/^accent$/i), { target: { value: "#cc3366" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save.*theme/i }));
+
+    await waitFor(() => {
+      expect(client.saveTheme).toHaveBeenCalledWith(
+        expect.objectContaining({
+          colors: expect.objectContaining({ accent: "#cc3366" }),
+        })
+      );
+    });
+  });
 });

--- a/frontend/src/components/ThemeSettings.css
+++ b/frontend/src/components/ThemeSettings.css
@@ -142,7 +142,6 @@
   background: var(--surface2);
   border: 1px solid var(--border);
   border-radius: 8px;
-  max-width: 600px;
 }
 
 .theme-editor input[type="text"] {
@@ -162,7 +161,7 @@
 
 .color-inputs {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
 }
 
@@ -180,12 +179,37 @@
   color: var(--text-muted);
 }
 
-.color-input-group input[type="color"] {
-  width: 100%;
-  height: 50px;
+.color-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.color-input-row input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  padding: 0.4rem 0.6rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.color-input-row input[type="text"]:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.color-input-row input[type="color"] {
+  width: 40px;
+  height: 36px;
+  padding: 2px;
   border: 1px solid var(--border);
   border-radius: 4px;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 .editor-actions {

--- a/frontend/src/components/ThemeSettings.jsx
+++ b/frontend/src/components/ThemeSettings.jsx
@@ -5,6 +5,11 @@ import { applyTheme } from "../utils/theme";
 import "./ThemeSettings.css";
 
 const DEFAULT_THEME_IDS = ["dark", "light", "charcoal", "paper", "pink", "frog"];
+
+const FULL_HEX_RE = /^#[0-9a-fA-F]{6}$/;
+function isValidHex(val) {
+  return FULL_HEX_RE.test(val);
+}
 const PROTECTED_THEME_IDS = ["dark", "light"];
 const PREVIEW_COLORS = ["primary", "secondary", "accent", "bg"];
 
@@ -14,6 +19,7 @@ export default function ThemeSettings() {
   const [customizingTheme, setCustomizingTheme] = useState(null); // Track which theme is being edited
   const [customName, setCustomName] = useState("");
   const [customColors, setCustomColors] = useState({});
+  const [hexInputs, setHexInputs] = useState({});
   const [error, setError] = useState(null);
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [renameTarget, setRenameTarget] = useState(null);
@@ -56,6 +62,7 @@ export default function ThemeSettings() {
       setCustomizingTheme(null);
       setCustomName("");
       setCustomColors({});
+      setHexInputs({});
       setError(null);
     },
     onError: (err) => {
@@ -72,6 +79,7 @@ export default function ThemeSettings() {
       setCustomizingTheme(null);
       setCustomName("");
       setCustomColors({});
+      setHexInputs({});
       setError(null);
     },
     onError: (err) => {
@@ -109,6 +117,7 @@ export default function ThemeSettings() {
     const themeToCustomize = theme || currentTheme;
     if (themeToCustomize?.colors) {
       setCustomColors({ ...themeToCustomize.colors });
+      setHexInputs({ ...themeToCustomize.colors });
       setCustomName(theme ? themeToCustomize.name : `${themeToCustomize.name} Custom`);
       setCustomizingTheme(theme ? themeToCustomize.id : null);
       setCustomizing(true);
@@ -118,6 +127,7 @@ export default function ThemeSettings() {
   const handleCopyTheme = (theme) => {
     if (theme?.colors) {
       setCustomColors({ ...theme.colors });
+      setHexInputs({ ...theme.colors });
       setCustomName(`${theme.name} Copy`);
       setCustomizingTheme(null);
       setCustomizing(true);
@@ -265,14 +275,39 @@ export default function ThemeSettings() {
           <div className="color-inputs">
             {["bg", "surface", "surface2", "accent", "primary", "secondary", "success", "warning", "error"].map((key) => (
               <div key={key} className="color-input-group">
-                <label htmlFor={`color-${key}`}>{key.charAt(0).toUpperCase() + key.slice(1)}</label>
-                <input
-                  id={`color-${key}`}
-                  type="color"
-                  value={customColors[key] || "#000000"}
-                  onChange={(e) => handleColorChange(key, e.target.value)}
-                  disabled={saveThemeMutation.isPending || updateThemeMutation.isPending}
-                />
+                <label htmlFor={`color-text-${key}`}>{key.charAt(0).toUpperCase() + key.slice(1)}</label>
+                <div className="color-input-row">
+                  <input
+                    id={`color-text-${key}`}
+                    type="text"
+                    value={hexInputs[key] ?? customColors[key] ?? "#000000"}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const val = raw.startsWith("#") ? raw : `#${raw}`;
+                      setHexInputs((prev) => ({ ...prev, [key]: val }));
+                      if (isValidHex(val)) {
+                        handleColorChange(key, val.toLowerCase());
+                      }
+                    }}
+                    disabled={saveThemeMutation.isPending || updateThemeMutation.isPending}
+                    placeholder="#rrggbb"
+                    maxLength={7}
+                    spellCheck={false}
+                    aria-label={`${key} hex`}
+                  />
+                  <input
+                    id={`color-${key}`}
+                    type="color"
+                    value={customColors[key] || "#000000"}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      handleColorChange(key, val);
+                      setHexInputs((prev) => ({ ...prev, [key]: val }));
+                    }}
+                    disabled={saveThemeMutation.isPending || updateThemeMutation.isPending}
+                    aria-label={`${key} picker`}
+                  />
+                </div>
               </div>
             ))}
           </div>
@@ -290,6 +325,7 @@ export default function ThemeSettings() {
               onClick={() => {
                 setCustomizing(false);
                 setCustomizingTheme(null);
+                setHexInputs({});
               }}
               disabled={saveThemeMutation.isPending || updateThemeMutation.isPending}
             >


### PR DESCRIPTION
## Summary

- Each color slot in the theme editor now has a hex text input and `type="color"` picker side by side
- Typing a valid `#rrggbb` value updates the picker in real time; picking a color syncs the text field
- Incomplete or invalid hex (e.g. `#abc`, `#gg0000`) is ignored — only applied on valid complete hex
- `#` prefix auto-normalized (typing `ff0000` displays as `#ff0000`)
- Added `frontend/.dockerignore` to exclude `node_modules` from Docker build context (prevents BuildKit cache conflicts in worktrees)

## Test plan

- [ ] Open theme editor, verify each color slot shows hex text input + color swatch side by side
- [ ] Type a valid hex (`#cc3366`) — picker updates in real time
- [ ] Pick a color via swatch — text field syncs to hex value
- [ ] Type incomplete hex (`#abc`) — picker does not update, saved value unchanged
- [ ] Type invalid chars (`#gg0000`) — picker does not update
- [ ] Type without `#` prefix (`ff0000`) — displays as `#ff0000`
- [ ] Save theme after hex-typed value — saves correctly
- [ ] All 23 ThemeSettings tests pass

## Closes

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)