### PR TITLE
feat: Apply unified theme colors across all pages (#115-120)

### DIFF
--- a/frontend/src/__tests__/UserCard.test.jsx
+++ b/frontend/src/__tests__/UserCard.test.jsx
@@ -135,27 +135,27 @@ describe("UserCard", () => {
     expect(dueSoonHeaders.length).toBeGreaterThan(0);
   });
 
-  it("shows green color for points ahead of goal (>0.8)", () => {
+  it("shows success color for points ahead of goal (>0.8)", () => {
     const aheadSummary = { person: "Alice", points_7d: 20, points_30d: 25 };
     const personWithGoal = { ...PERSON, goal_7d: 20, goal_30d: 30 };
     wrap(<UserCard person={personWithGoal} chores={[]} people={PEOPLE} summary={aheadSummary} />);
     const points7d = screen.getAllByText("20")[0];
-    expect(points7d).toHaveStyle({ color: "#3db87a" });
+    expect(points7d).toHaveStyle({ color: "var(--success)" });
   });
 
-  it("shows yellow color for points on-track (0.5-0.8)", () => {
+  it("shows warning color for points on-track (0.5-0.8)", () => {
     const onTrackSummary = { person: "Alice", points_7d: 10, points_30d: 25 };
     const personWithGoal = { ...PERSON, goal_7d: 20, goal_30d: 50 };
     wrap(<UserCard person={personWithGoal} chores={[]} people={PEOPLE} summary={onTrackSummary} />);
     const points7d = screen.getByText("10");
-    expect(points7d).toHaveStyle({ color: "#e8a930" });
+    expect(points7d).toHaveStyle({ color: "var(--warning)" });
   });
 
-  it("shows red color for points behind goal (<0.5)", () => {
+  it("shows error color for points behind goal (<0.5)", () => {
     const behindSummary = { person: "Alice", points_7d: 5, points_30d: 25 };
     const personWithGoal = { ...PERSON, goal_7d: 20, goal_30d: 50 };
     wrap(<UserCard person={personWithGoal} chores={[]} people={PEOPLE} summary={behindSummary} />);
     const points7d = screen.getByText("5");
-    expect(points7d).toHaveStyle({ color: "#e05c6a" });
+    expect(points7d).toHaveStyle({ color: "var(--error)" });
   });
 });

--- a/frontend/src/__tests__/trendStatus.test.js
+++ b/frontend/src/__tests__/trendStatus.test.js
@@ -28,22 +28,24 @@ describe("trendStatus", () => {
   });
 
   describe("getTrendColor", () => {
-    it("returns green for ahead status", () => {
-      const color = getTrendColor("ahead");
-      expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    it("returns success CSS variable for ahead status", () => {
+      expect(getTrendColor("ahead")).toBe("var(--success)");
     });
 
-    it("returns yellow for on-track status", () => {
-      const color = getTrendColor("on-track");
-      expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    it("returns warning CSS variable for on-track status", () => {
+      expect(getTrendColor("on-track")).toBe("var(--warning)");
     });
 
-    it("returns red for behind status", () => {
-      const color = getTrendColor("behind");
-      expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    it("returns error CSS variable for behind status", () => {
+      expect(getTrendColor("behind")).toBe("var(--error)");
     });
 
-    it("returns different colors for different statuses", () => {
+    it("returns text CSS variable for unknown status", () => {
+      expect(getTrendColor("unknown")).toBe("var(--text)");
+      expect(getTrendColor(undefined)).toBe("var(--text)");
+    });
+
+    it("returns different CSS variables for different statuses", () => {
       const ahead = getTrendColor("ahead");
       const onTrack = getTrendColor("on-track");
       const behind = getTrendColor("behind");

--- a/frontend/src/components/ChoreForm.css
+++ b/frontend/src/components/ChoreForm.css
@@ -114,7 +114,7 @@
 
 .day-btn.active {
   background: var(--accent-btn);
-  color: #fff;
+  color: var(--on-primary);
   border-color: var(--accent-btn);
 }
 
@@ -137,7 +137,7 @@
 
 .person-btn.active {
   background: var(--accent-btn);
-  color: #fff;
+  color: var(--on-primary);
   border-color: var(--accent-btn);
 }
 
@@ -200,7 +200,7 @@
   color: var(--error);
   font-size: 0.875rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(248, 113, 113, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border-radius: var(--radius);
   border: 1px solid var(--error);
 }
@@ -234,7 +234,7 @@
   transform: translateY(-50%);
   width: 1rem;
   height: 1rem;
-  background: #fff;
+  background: var(--on-primary);
   border-radius: 50%;
   transition: left 0.3s ease;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
@@ -278,7 +278,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/ChoreList.css
+++ b/frontend/src/components/ChoreList.css
@@ -49,12 +49,12 @@
 }
 
 .chore-state-badge.due {
-  background: rgba(224, 92, 106, 0.15);
+  background: rgba(var(--error-rgb), 0.15);
   color: var(--error);
 }
 
 .chore-state-badge.complete {
-  background: rgba(61, 184, 122, 0.15);
+  background: rgba(var(--success-rgb), 0.15);
   color: var(--success);
 }
 
@@ -97,7 +97,7 @@
 }
 
 .chore-action-delete:hover {
-  color: #ff6b6b;
+  color: var(--error);
 }
 
 .chore-content {
@@ -215,7 +215,7 @@
   width: fit-content;
   padding: 0.3rem 0.6rem;
   border-radius: 999px;
-  background: rgba(115, 177, 221, 0.12);
+  background: rgba(var(--accent-rgb), 0.12);
   color: var(--text);
 }
 
@@ -260,17 +260,17 @@
 }
 
 .assignment-info.rotating {
-  background: rgba(115, 177, 221, 0.15);
+  background: rgba(var(--accent-rgb), 0.15);
   color: var(--accent);
 }
 
 .assignment-info.open {
-  background: rgba(232, 169, 48, 0.15);
+  background: rgba(var(--warning-rgb), 0.15);
   color: var(--warning);
 }
 
 .assignment-info.fixed {
-  background: rgba(61, 184, 122, 0.15);
+  background: rgba(var(--success-rgb), 0.15);
   color: var(--success);
 }
 

--- a/frontend/src/components/ChoreRowActions.css
+++ b/frontend/src/components/ChoreRowActions.css
@@ -36,7 +36,7 @@
 
 .chore-icon-check {
   font-size: 16px;
-  color: #fff;
+  color: var(--on-primary);
 }
 
 .chore-icon-pts {

--- a/frontend/src/components/ExportImport.css
+++ b/frontend/src/components/ExportImport.css
@@ -128,13 +128,13 @@
 }
 
 .error-message {
-  background: rgba(224, 92, 106, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   color: var(--error);
   border: 1px solid var(--error);
 }
 
 .success-message {
-  background: rgba(61, 184, 122, 0.1);
+  background: rgba(var(--success-rgb), 0.1);
   color: var(--success);
   border: 1px solid var(--success);
 }

--- a/frontend/src/components/Log.css
+++ b/frontend/src/components/Log.css
@@ -186,6 +186,19 @@
   border: 1px solid var(--border);
 }
 
+/* Semantic action colors */
+.action-badge--completed  { border-color: var(--success); color: var(--success); }
+.action-badge--created    { border-color: var(--success); color: var(--success); }
+.action-badge--skipped    { border-color: var(--warning); color: var(--warning); }
+.action-badge--marked_due { border-color: var(--warning); color: var(--warning); }
+.action-badge--deleted    { border-color: var(--error);   color: var(--error); }
+.action-badge--reassigned { border-color: var(--accent);  color: var(--accent); }
+.action-badge--updated    { border-color: var(--accent);  color: var(--accent); }
+
+/* Semantic target type colors */
+.target-badge--chore { border-color: var(--accent); color: var(--accent); }
+.target-badge--user  { border-color: var(--gold);   color: var(--gold); }
+
 /* Detail row — expands inline below the clicked row */
 .log-detail-row {
   cursor: pointer;

--- a/frontend/src/components/Log.jsx
+++ b/frontend/src/components/Log.jsx
@@ -35,6 +35,8 @@ function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
 
   const targetType = entry.chore_name.startsWith("Person:") ? "user" : "chore";
   const targetName = entry.chore_name.replace("Person: ", "");
+  const actionClass = `action-badge action-badge--${entry.action}`;
+  const targetClass = `target-badge target-badge--${targetType}`;
   const fullTimestamp = new Date(entry.timestamp).toLocaleString();
 
   const handleClick = () => {
@@ -60,11 +62,11 @@ function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
       >
         <td className="log-timestamp">{formatTimestamp(entry.timestamp)}</td>
         <td className="log-action">
-          <span className="action-badge">{entry.action}</span>
+          <span className={actionClass}>{entry.action}</span>
         </td>
         {!isMobile && (
           <td className="log-target-type">
-            <span className="target-badge">{targetType}</span>
+            <span className={targetClass}>{targetType}</span>
           </td>
         )}
         {!isMobile && (

--- a/frontend/src/components/Modal.css
+++ b/frontend/src/components/Modal.css
@@ -1,7 +1,7 @@
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/RedemptionModal.css
+++ b/frontend/src/components/RedemptionModal.css
@@ -12,9 +12,9 @@
 }
 
 .redemption-modal {
-  background: white;
+  background: var(--surface);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   max-width: 500px;
   width: 90%;
   max-height: 80vh;
@@ -28,7 +28,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 24px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--border);
 }
 
 .modal-header h2 {
@@ -42,7 +42,7 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: #6b7280;
+  color: var(--text-muted);
   padding: 0;
   width: 32px;
   height: 32px;
@@ -54,7 +54,7 @@
 }
 
 .close-btn:hover:not(:disabled) {
-  background-color: #f3f4f6;
+  background-color: var(--surface2);
 }
 
 .close-btn:disabled {
@@ -78,7 +78,7 @@
 }
 
 .points-info {
-  background-color: #f9fafb;
+  background: var(--surface2);
   border-radius: 6px;
   padding: 12px;
   margin-bottom: 16px;
@@ -89,26 +89,26 @@
   justify-content: space-between;
   padding: 8px 0;
   font-size: 14px;
-  color: #374151;
+  color: var(--text);
 }
 
 .point-row strong {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--text);
 }
 
 .available-points-display {
   text-align: center;
   padding: 24px;
-  background-color: #f9fafb;
+  background: var(--surface2);
   border-radius: 6px;
-  border: 2px solid #059669;
+  border: 2px solid var(--success);
 }
 
 .available-number {
   font-size: 3rem;
   font-weight: 700;
-  color: #059669;
+  color: var(--success);
   margin-bottom: 8px;
 }
 
@@ -128,37 +128,39 @@
   margin-bottom: 8px;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: var(--text);
 }
 
 .input-section input {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
   border-radius: 6px;
   font-size: 14px;
   box-sizing: border-box;
+  background: var(--surface2);
+  color: var(--text);
   transition: border-color 0.2s;
 }
 
 .input-section input:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.1);
 }
 
 .input-section input:disabled {
-  background-color: #f3f4f6;
-  color: #9ca3af;
+  background: var(--surface2);
+  color: var(--text-muted);
   cursor: not-allowed;
 }
 
 .no-points {
   margin: 0;
   padding: 12px;
-  background-color: #fef3c7;
+  background: rgba(var(--warning-rgb), 0.15);
   border-radius: 6px;
-  color: #92400e;
+  color: var(--warning);
   font-size: 14px;
 }
 
@@ -169,7 +171,7 @@
 .confirm-text {
   margin: 0 0 16px 0;
   font-size: 16px;
-  color: #1f2937;
+  color: var(--text);
 }
 
 .confirm-text strong {
@@ -177,7 +179,7 @@
 }
 
 .confirm-details {
-  background-color: #f9fafb;
+  background: var(--surface2);
   border-radius: 6px;
   padding: 12px;
   margin-top: 16px;
@@ -186,29 +188,24 @@
 .confirm-details p {
   margin: 8px 0;
   font-size: 14px;
-  color: #374151;
+  color: var(--text);
   display: flex;
   justify-content: space-between;
 }
 
 .confirm-details p strong {
   font-weight: 600;
-  color: #1f2937;
-}
-
-.confirm-details p strong {
-  font-weight: 600;
-  color: #1f2937;
+  color: var(--text);
 }
 
 .error-message {
   margin: 16px 0 0 0;
   padding: 12px;
-  background-color: #fee2e2;
+  background: rgba(var(--error-rgb), 0.15);
   border-radius: 6px;
-  color: #991b1b;
+  color: var(--error);
   font-size: 14px;
-  border-left: 3px solid #dc2626;
+  border-left: 3px solid var(--error);
 }
 
 .modal-footer {
@@ -216,7 +213,7 @@
   gap: 12px;
   justify-content: flex-end;
   padding: 16px 24px;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--border);
 }
 
 .btn-cancel,
@@ -232,30 +229,13 @@
 }
 
 .btn-cancel {
-  background-color: #f3f4f6;
-  color: #1f2937;
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
 }
 
 .btn-cancel:hover:not(:disabled) {
-  background-color: #e5e7eb;
-}
-
-.btn-primary {
-  background-color: #3b82f6;
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background-color: #2563eb;
-}
-
-.btn-error {
-  background-color: #dc2626;
-  color: white;
-}
-
-.btn-error:hover:not(:disabled) {
-  background-color: #b91c1c;
+  background: var(--border);
 }
 
 .btn-cancel:disabled,

--- a/frontend/src/components/ThemeSettings.css
+++ b/frontend/src/components/ThemeSettings.css
@@ -239,7 +239,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/ThemeSettings.css
+++ b/frontend/src/components/ThemeSettings.css
@@ -46,7 +46,7 @@
 .theme-card.theme-active {
   border-color: var(--accent);
   background: var(--surface);
-  box-shadow: 0 0 8px rgba(115, 177, 221, 0.3);
+  box-shadow: 0 0 8px rgba(var(--accent-rgb), 0.3);
 }
 
 .theme-preview {
@@ -220,7 +220,7 @@
 
 .error-message {
   padding: 0.75rem;
-  background: rgba(224, 92, 106, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border: 1px solid var(--error);
   border-radius: 4px;
   color: var(--error);

--- a/frontend/src/components/ThemeSettings.jsx
+++ b/frontend/src/components/ThemeSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getThemes, getCurrentTheme, setTheme, saveTheme, deleteTheme, renameTheme, updateTheme } from "../api/client";
-import { applyTheme } from "../utils/theme";
+import { applyTheme, DEFAULT_THEME_COLORS } from "../utils/theme";
 import "./ThemeSettings.css";
 
 const DEFAULT_THEME_IDS = ["dark", "light", "charcoal", "paper", "pink", "frog"];
@@ -280,7 +280,7 @@ export default function ThemeSettings() {
                   <input
                     id={`color-text-${key}`}
                     type="text"
-                    value={hexInputs[key] ?? customColors[key] ?? "#000000"}
+                    value={hexInputs[key] ?? customColors[key] ?? DEFAULT_THEME_COLORS[key]}
                     onChange={(e) => {
                       const raw = e.target.value;
                       const val = raw.startsWith("#") ? raw : `#${raw}`;
@@ -298,7 +298,7 @@ export default function ThemeSettings() {
                   <input
                     id={`color-${key}`}
                     type="color"
-                    value={customColors[key] || "#000000"}
+                    value={customColors[key] || DEFAULT_THEME_COLORS[key]}
                     onChange={(e) => {
                       const val = e.target.value;
                       handleColorChange(key, val);

--- a/frontend/src/components/UserManagement.css
+++ b/frontend/src/components/UserManagement.css
@@ -175,7 +175,7 @@
 }
 
 .user-action-link:hover {
-  color: var(--accent-hover);
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -189,7 +189,8 @@
 }
 
 .user-action-delete:hover {
-  color: #ff6b6b;
+  color: var(--error);
+  opacity: 0.85;
 }
 
 .user-properties {
@@ -292,7 +293,7 @@
 
 .error-message {
   padding: 0.75rem 1rem;
-  background: rgba(224, 92, 106, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border: 1px solid var(--error);
   border-radius: 4px;
   color: var(--error);
@@ -369,12 +370,12 @@
 .modal-dialog {
   background: var(--surface2);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius);
   max-width: 500px;
   width: 90%;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow);
 }
 
 .modal-header {

--- a/frontend/src/components/UserManagement.css
+++ b/frontend/src/components/UserManagement.css
@@ -359,7 +359,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,7 +17,12 @@
   --error: #e05c6a;
   --error-rgb: 224,92,106;
   --warning: #e8a930;
+  --warning-rgb: 232,169,48;
   --success: #3db87a;
+  --success-rgb: 61,184,122;
+  --accent-rgb: 115,177,221;
+  --on-primary: #ffffff;
+  --overlay: rgba(0,0,0,0.6);
   --radius: 12px;
   --shadow: 0 1px 4px rgba(0,0,0,0.3), 0 4px 16px rgba(0,0,0,0.2);
   --shadow-lg: 0 2px 8px rgba(0,0,0,0.4), 0 12px 40px rgba(0,0,0,0.3);
@@ -44,9 +49,9 @@ button {
 button:disabled { opacity: 0.4; cursor: not-allowed; }
 button:not(:disabled):hover { opacity: 0.85; }
 
-.btn-primary { background: var(--accent-btn); color: #fff; }
+.btn-primary { background: var(--accent-btn); color: var(--on-primary); }
 .btn-secondary { background: var(--surface2); color: var(--text); border: 1px solid var(--border); }
-.btn-error { background: var(--error); color: #fff; }
+.btn-error { background: var(--error); color: var(--on-primary); }
 .btn-warning { background: var(--warning); color: var(--bg); }
 
 @keyframes slideUp {

--- a/frontend/src/pages/Chores.css
+++ b/frontend/src/pages/Chores.css
@@ -108,8 +108,8 @@
   text-transform: uppercase;
 }
 .assign-badge.open { background: var(--surface2); color: var(--text-muted); }
-.assign-badge.fixed { background: var(--accent-btn); color: #fff; }
-.assign-badge.rotating { background: #6d4aad; color: #fff; }
+.assign-badge.fixed { background: var(--accent-btn); color: var(--on-primary); }
+.assign-badge.rotating { background: var(--secondary); color: var(--on-primary); }
 
 .assignee-name { font-size: 0.85rem; color: var(--text-muted); }
 

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -95,7 +95,7 @@
 
 .error-message {
   padding: 0.75rem 1rem;
-  background: rgba(224, 92, 106, 0.1);
+  background: rgba(var(--error-rgb), 0.1);
   border: 1px solid var(--error);
   border-radius: 4px;
   color: var(--error);
@@ -104,7 +104,7 @@
 
 .success-message {
   padding: 0.75rem 1rem;
-  background: rgba(61, 184, 122, 0.1);
+  background: rgba(var(--success-rgb), 0.1);
   border: 1px solid var(--success);
   border-radius: 4px;
   color: var(--success);

--- a/frontend/src/pages/UserDetail.css
+++ b/frontend/src/pages/UserDetail.css
@@ -61,8 +61,8 @@
 }
 
 .redeem-btn {
-  background: var(--accent);
-  color: white;
+  background: var(--primary);
+  color: var(--on-primary);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -29,13 +29,18 @@ export function applyTheme(colors) {
   root.style.setProperty("--warning", colors.warning);
   root.style.setProperty("--error", colors.error);
 
-  // Keep --error-rgb in sync so rgba(var(--error-rgb), alpha) patterns work
-  if (colors.error) {
-    const r = parseInt(colors.error.slice(1, 3), 16);
-    const g = parseInt(colors.error.slice(3, 5), 16);
-    const b = parseInt(colors.error.slice(5, 7), 16);
-    root.style.setProperty("--error-rgb", `${r},${g},${b}`);
-  }
+  // Keep *-rgb vars in sync so rgba(var(--*-rgb), alpha) patterns work
+  const syncRgb = (varName, hex) => {
+    if (!hex) return;
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    root.style.setProperty(varName, `${r},${g},${b}`);
+  };
+  syncRgb("--error-rgb", colors.error);
+  syncRgb("--success-rgb", colors.success);
+  syncRgb("--accent-rgb", colors.accent);
+  syncRgb("--warning-rgb", colors.warning);
 
   const bgBrightness = getBrightness(colors.bg);
   if (bgBrightness > 128) {

--- a/frontend/src/utils/trendStatus.js
+++ b/frontend/src/utils/trendStatus.js
@@ -8,9 +8,9 @@ export function getTrendStatus(points, goal) {
 
 export function getTrendColor(status) {
   const colors = {
-    ahead: "#3db87a",
-    "on-track": "#e8a930",
-    behind: "#e05c6a",
+    ahead: "var(--success)",
+    "on-track": "var(--warning)",
+    behind: "var(--error)",
   };
-  return colors[status] || "#dce8f5";
+  return colors[status] || "var(--text)";
 }


### PR DESCRIPTION
## Summary

- Replace all hardcoded hex/rgba color values with CSS custom properties across every page and component
- Covers Home/Board (#115), Chores (#116), Users (#117), User Details (#118), Log (#119), and Settings (#120)
- Adds missing RGB companion tokens (`--success-rgb`, `--warning-rgb`, `--accent-rgb`) and `--on-primary`/`--overlay` globals so all semi-transparent tints work correctly across theme switches
- `applyTheme()` in `theme.js` now syncs all RGB companion vars, keeping custom themes consistent

## Test plan

- [ ] All 237 backend tests pass
- [ ] Frontend tests pass (1 pre-existing unrelated failure in `UserCard` `shows due soon count`)
- [ ] Switch between built-in themes — verify all pages reflect the active theme with no hardcoded color bleed
- [ ] Set a custom theme — verify rgba tinted backgrounds (badges, modals, error/success messages) update correctly
- [ ] Check Log page action/target badges show correct semantic colors (green=completed, amber=skipped, red=deleted, blue=reassigned)
- [ ] Check Redemption modal inputs, disabled states, and error/warning banners in dark mode

Closes #115
Closes #116
Closes #117
Closes #118
Closes #119
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)