### PR TITLE
fix(frontend): prevent adjacent column cards from stretching on expand (#227)

### DIFF
--- a/frontend/src/components/ChoreList.css
+++ b/frontend/src/components/ChoreList.css
@@ -7,6 +7,7 @@
 @media (min-width: 1200px) {
   .chore-list {
     grid-template-columns: repeat(2, 1fr);
+    align-items: start;
   }
 }
 


### PR DESCRIPTION
## Summary

- CSS Grid `align-items: stretch` (default) caused cards in the opposite column to grow in height when a card was expanded, showing a large empty space
- Added `align-items: start` to `.chore-list` inside the `@media (min-width: 1200px)` block so each card's height is determined solely by its own content
- Single-line CSS change; no JS or backend impact; scoped to the responsive breakpoint so single-column layout is unaffected

## Changes

- `frontend/src/components/ChoreList.css` — +1 line

## Test plan

- [ ] Load `/chores` at ≥ 1200px viewport width
- [ ] Expand a card — adjacent card in other column does not stretch to match height
- [ ] Collapse card — normal height restored
- [ ] Verify no effect at < 1200px viewport (single-column layout unchanged)

## References

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)