### PR TITLE
feat(ai): add grill-me skill and doc-aware planning/implementation

### DIFF
--- a/.claude/agents/github-issue-implementation-orchestrator.md
+++ b/.claude/agents/github-issue-implementation-orchestrator.md
@@ -29,9 +29,17 @@ START
           ↓
 [3] implement
   ├─ Call: /implementation-implement <issue-number>
+  ├─ Pre-work: Update docs/ pages identified in implementation plan before writing code
+  │  ├─ Read affected doc pages from plan's documentation section
+  │  ├─ Draft documentation changes for the planned feature/fix
+  │  └─ Commit doc drafts alongside code (or stage for final review)
   ├─ Executes: Code changes across DB, backend, frontend, tests
   ├─ Follows: Implementation plan from planning phase
-  └─ Result: Files modified, implementation complete
+  ├─ Post-work: Review and correct documentation after code is complete
+  │  ├─ Re-read modified doc pages to verify accuracy against actual implementation
+  │  ├─ Correct any discrepancies between docs and code
+  │  └─ Add missing doc coverage for new behavior
+  └─ Result: Files modified, implementation complete, docs updated
           ↓
 [4] test
   ├─ Call: /implementation-test
@@ -117,6 +125,7 @@ Resumable by checking current branch state and git status.
 ### Output
 - Fully implemented issue with:
   - Code changes across affected layers (via implementation-implement skill)
+  - Documentation updated before and verified after implementation
   - All tests passing (via implementation-test skill)
   - Docker containers running with changes (via implementation-verify skill)
   - Conventional commit with issue reference (via implementation-finalize skill)

--- a/.claude/agents/github-issue-plan-orchestrator.md
+++ b/.claude/agents/github-issue-plan-orchestrator.md
@@ -38,6 +38,11 @@ START
   │  ├─ Trace call paths: router → service → model → DB
   │  ├─ Study similar existing implementations for patterns
   │  └─ Identify exact files/functions requiring changes
+  ├─ Identify affected documentation
+  │  ├─ Search docs/ directory for pages related to changed features
+  │  ├─ Flag doc pages covering changed API endpoints, UI flows, or configuration
+  │  ├─ Note gaps: new features or changed behavior with no existing doc coverage
+  │  └─ List affected doc files in implementation plan for later update
   ├─ Identify affected tests
   │  ├─ Find existing tests covering changed code (grep test files for function/route names)
   │  ├─ Flag tests that will break due to signature, schema, or behavior changes
@@ -50,7 +55,8 @@ START
   │  ├─ Affected Files
   │  │  ├─ Database: specific migration files, model changes
   │  │  ├─ Backend: exact file paths and line ranges
-  │  │  └─ Frontend: exact component paths and functions
+  │  │  ├─ Frontend: exact component paths and functions
+  │  │  └─ Documentation: docs/ pages covering affected features or APIs
   │  ├─ Implementation Steps (3-5 concrete, ordered steps)
   │  │  ├─ Specific function/API changes
   │  │  ├─ Schema modifications if applicable
@@ -86,7 +92,7 @@ START
   ├─ Format final plan summary (markdown)
   ├─ Post plan as issue comment
   │  ├─ gh issue comment <number> --body "<formatted-plan>"
-  │  └─ Include: affected files, steps, test changes (modify/add/remove), challenges, rationale
+  │  └─ Include: affected files, steps, test changes (modify/add/remove), doc changes, challenges, rationale
   ├─ Remove ready-to-plan label
   │  └─ gh issue edit <number> --remove-label ready-to-plan
   ├─ Add ready-for-work label

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.claude/skills/implementation-implement/SKILL.md
+++ b/.claude/skills/implementation-implement/SKILL.md
@@ -17,13 +17,21 @@ Implements code changes to address GitHub issue requirements.
 
 1. **Fetch issue details**: Get issue title, body, and existing comments
 2. **Read implementation plan**: Check for plan posted in issue comments
-3. **Identify affected layers**:
+3. **Update documentation (pre-work)**: Before writing code, update docs/ pages listed in the plan
+   - Read each affected doc page from the plan's documentation section
+   - Draft documentation changes to reflect planned behavior
+   - Stage doc changes alongside code
+4. **Identify affected layers**:
    - Database: Schema changes, migrations
    - Backend: Services, routers, schemas
    - Frontend: Components, API client, UI
-4. **Implement changes**: Make code modifications per plan
-5. **Track changes**: Note which files modified and impact
-6. **Report summary**: Show files changed and what was implemented
+5. **Implement changes**: Make code modifications per plan
+6. **Review and correct documentation (post-work)**: After code changes are complete
+   - Re-read all modified doc pages
+   - Verify docs accurately reflect the actual implementation
+   - Correct any discrepancies; add coverage for new behavior
+7. **Track changes**: Note which files modified and impact
+8. **Report summary**: Show files changed and what was implemented
 
 ## Implementation Scope
 


### PR DESCRIPTION
## Summary

- Add `grill-me` skill that interviews users about plans one question at a time, providing a recommended answer for each question and exploring the codebase when possible instead of asking
- Update `github-issue-plan-orchestrator` explore step to identify affected `docs/` pages and include them in the implementation plan's affected files section
- Update `github-issue-implementation-orchestrator` and `implementation-implement` skill to update documentation before writing code, then review and correct it after implementation is complete

## Test plan

- [ ] Verify `grill-me` skill appears in available skills list
- [ ] Run `/grill-me` on a design topic and confirm it asks one question at a time with recommended answers
- [ ] Run plan orchestrator on a new issue and confirm explore step searches `docs/` for affected pages
- [ ] Run implementation orchestrator and confirm doc update steps appear in the implement phase output
- [ ] All 253 backend tests pass

Closes #233

Generated with [Claude Code](https://claude.com/claude-code)