### PR TITLE
fix(frontend): keep highlight color on expanded chore card (#226)

### DIFF
--- a/frontend/src/__tests__/ChoreCard.test.jsx
+++ b/frontend/src/__tests__/ChoreCard.test.jsx
@@ -198,4 +198,24 @@ describe("ChoreCard", () => {
     );
     expect(container.querySelector(".chore-card")).toHaveClass("done");
   });
+
+  it("applies expanded class to card when expanded", () => {
+    const { container } = render(
+      <ChoreCard chore={makeChore()} selected={false} onClick={() => {}} />
+    );
+    const card = container.querySelector(".chore-card");
+    fireEvent.click(card);
+    expect(card).toHaveClass("expanded");
+  });
+
+  it("applies collapsed class to card when collapsed", () => {
+    const { container } = render(
+      <ChoreCard chore={makeChore()} selected={false} onClick={() => {}} />
+    );
+    const card = container.querySelector(".chore-card");
+    expect(card).toHaveClass("collapsed");
+    fireEvent.click(card);
+    fireEvent.click(card);
+    expect(card).toHaveClass("collapsed");
+  });
 });

--- a/frontend/src/components/ChoreCard.css
+++ b/frontend/src/components/ChoreCard.css
@@ -10,7 +10,8 @@
   overflow: hidden;
 }
 
-.chore-card:hover {
+.chore-card:hover,
+.chore-card.expanded {
   background: var(--surface2);
   filter: brightness(1.05) saturate(1.1);
 }


### PR DESCRIPTION
## Summary

- Expanded chore cards now maintain their highlight background color even when the mouse is not hovering over them
- Previously, the highlight was only applied via `:hover`, so moving the cursor away from an expanded card caused it to lose its visual state
- Added `.expanded` CSS class selector alongside `:hover` so the card stays highlighted while open and reverts to default on collapse

## Changes

- `frontend/src/components/ChoreCard.css` — added `.chore-card.expanded` selector to the hover highlight rule
- `frontend/src/__tests__/ChoreCard.test.jsx` — added two tests covering expanded and collapsed class behavior

## Test plan

- [ ] Expand a chore card and move the mouse away — card should remain highlighted
- [ ] Collapse the card — highlight should only appear on hover again
- [ ] Frontend unit tests pass: `npm test -- --watchAll=false`

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)