### PR TITLE
feat(frontend): refine log view with relative timestamps and redesigned badges

### DIFF
--- a/frontend/src/__tests__/Log.test.jsx
+++ b/frontend/src/__tests__/Log.test.jsx
@@ -1,22 +1,12 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import Log from "../components/Log";
 import * as client from "../api/client";
 
 vi.mock("../api/client");
-
-// Mock window.innerWidth for breakpoint testing
-function setViewportWidth(width) {
-  Object.defineProperty(window, "innerWidth", {
-    writable: true,
-    configurable: true,
-    value: width,
-  });
-  window.dispatchEvent(new Event("resize"));
-}
 
 const LOG_ENTRIES = [
   {
@@ -95,7 +85,7 @@ describe("Log", () => {
     });
   });
 
-  it("shows log entry details (person, chore, action, timestamp)", async () => {
+  it("shows log entry details (action badges visible)", async () => {
     wrap(<Log />);
     await waitFor(() => {
       const actions = screen.getAllByText(/completed|skipped|reassigned/i);
@@ -106,7 +96,6 @@ describe("Log", () => {
   it("renders a table structure", async () => {
     wrap(<Log />);
     await waitFor(() => {
-      // Should have a table element
       expect(document.querySelector("table.log-table")).toBeInTheDocument();
       expect(document.querySelector("thead")).toBeInTheDocument();
       expect(document.querySelector("tbody")).toBeInTheDocument();
@@ -297,39 +286,70 @@ describe("Log", () => {
     });
   });
 
+  describe("Column layout", () => {
+    it("shows 5 column headers: Timestamp, Target Type, Action, Actor, Target", async () => {
+      wrap(<Log />);
+      await waitFor(() => {
+        expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Target Type").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Action").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Actor").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Target").length).toBeGreaterThan(0);
+      });
+    });
+
+    it("does not show Assignee as a column header", async () => {
+      wrap(<Log />);
+      await waitFor(() => {
+        const vacuums = screen.queryAllByText("Vacuum");
+        expect(vacuums.length).toBeGreaterThan(0);
+      });
+      expect(screen.queryByRole("columnheader", { name: "Assignee" })).not.toBeInTheDocument();
+    });
+
+    it("never shows Content column", async () => {
+      wrap(<Log />);
+      await waitFor(() => {
+        expect(screen.queryByText("Content")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Relative timestamps", () => {
+    it("formats timestamps as relative time (e.g. Xd ago for old entries)", async () => {
+      wrap(<Log />);
+      await waitFor(() => {
+        // All test entries are from April 2026 (>24h old from May 2026 test run)
+        const relTimestamps = screen.getAllByText(/\d+[mhd] ago|just now/);
+        expect(relTimestamps.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
   describe("Log entry inline expand (detail row)", () => {
     it("clicking a row inserts a detail row below it", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // No modal or dialog ever appears
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-      // No article cards
       expect(screen.queryByRole("article")).not.toBeInTheDocument();
-
-      // Before click: no detail rows in the DOM
       expect(document.querySelectorAll("tr.log-detail-row").length).toBe(0);
 
-      // Click the first data row
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[0]);
 
       await waitFor(() => {
-        // Detail row appears — no modal
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-        // A detail row is now present
         expect(document.querySelectorAll("tr.log-detail-row").length).toBe(1);
-        // "Timestamp" appears in both thead and the detail row
+        // Timestamp appears in thead + detail row
         expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(1);
       });
     });
 
     it("clicking an expanded row removes the detail row", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -338,24 +358,19 @@ describe("Log", () => {
 
       const rows = document.querySelectorAll("tbody tr.log-table-row");
 
-      // Expand
       fireEvent.click(rows[0]);
       await waitFor(() => {
         expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(1);
       });
 
-      // Collapse
       fireEvent.click(rows[0]);
       await waitFor(() => {
-        // Detail labels gone; only the thead "Timestamp" remains
         expect(screen.getAllByText("Timestamp").length).toBe(1);
-        // No detail rows remain
         expect(document.querySelectorAll("tr.log-detail-row").length).toBe(0);
       });
     });
 
     it("detail row shows timestamp, actor, target type, and target labels", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -366,26 +381,21 @@ describe("Log", () => {
       fireEvent.click(rows[0]);
 
       await waitFor(() => {
-        // Detail row has all base labels (Timestamp appears in thead + detail row)
+        // These all appear in both thead and detail row (>1 each)
         expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(1);
-        // Actor appears in thead + detail row (>=2 at desktop)
         expect(screen.getAllByText("Actor").length).toBeGreaterThan(1);
-        // Target Type appears in thead + detail row (>=2 at desktop)
         expect(screen.getAllByText("Target Type").length).toBeGreaterThan(1);
-        // Target appears in thead + detail row (>=2 at desktop)
         expect(screen.getAllByText("Target").length).toBeGreaterThan(1);
       });
     });
 
     it("detail row shows reassigned_to when present", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // Entry index 2 (rows[2]) has reassigned_to: "Bob"
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[2]);
 
@@ -395,14 +405,12 @@ describe("Log", () => {
     });
 
     it("detail row hides reassigned_to when absent", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // Entry index 0 (completed, no reassigned_to)
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[0]);
 
@@ -414,33 +422,29 @@ describe("Log", () => {
     });
 
     it("detail row shows assignee when present", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // Entry index 0 (completed) has assignee: "Alice"
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[0]);
 
       await waitFor(() => {
-        // "Assignee" appears as both a <th> header and a detail label — use getAllByText
+        // Assignee is detail-only (not a column header), so exactly 1 occurrence
         const assigneeEls = screen.getAllByText("Assignee");
-        expect(assigneeEls.length).toBeGreaterThan(1);
+        expect(assigneeEls.length).toBeGreaterThan(0);
       });
     });
 
     it("detail row hides assignee when absent", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // Entry index 1 (skipped, no assignee)
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[1]);
 
@@ -448,22 +452,17 @@ describe("Log", () => {
         expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(1);
       });
 
-      // "Assignee" column header <th> is visible, but the detail row label <span> should not be.
-      // So exactly one "Assignee" element (the header) should exist.
-      const assigneeEls = screen.queryAllByText("Assignee");
-      expect(assigneeEls.length).toBe(1);
-      expect(assigneeEls[0].tagName).toBe("TH");
+      // No Assignee text: not in header, not in detail when absent
+      expect(screen.queryByText("Assignee")).not.toBeInTheDocument();
     });
 
     it("detail row shows field_name, old_value, new_value when present", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
         expect(vacuums.length).toBeGreaterThan(0);
       });
 
-      // Entry index 3 is the updated entry with field_name/old_value/new_value
       const rows = document.querySelectorAll("tbody tr.log-table-row");
       fireEvent.click(rows[3]);
 
@@ -478,7 +477,6 @@ describe("Log", () => {
     });
 
     it("pressing Enter on a row expands the detail row", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -496,7 +494,6 @@ describe("Log", () => {
     });
 
     it("pressing Space on a row expands the detail row", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -514,7 +511,6 @@ describe("Log", () => {
     });
 
     it("rows have tabIndex for keyboard navigation", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -526,7 +522,6 @@ describe("Log", () => {
     });
 
     it("rows have aria-expanded attribute", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -544,7 +539,6 @@ describe("Log", () => {
     });
 
     it("only one detail row is inserted per expanded row", async () => {
-      setViewportWidth(1024);
       wrap(<Log />);
       await waitFor(() => {
         const vacuums = screen.getAllByText("Vacuum");
@@ -562,7 +556,7 @@ describe("Log", () => {
   });
 
   describe("Person log entries (UserLog unified view)", () => {
-    it("shows target type 'user' for entries whose chore_name starts with 'Person:'", async () => {
+    it("shows target type 'user' badge in main row for entries whose chore_name starts with 'Person:'", async () => {
       const personEntry = {
         id: 99,
         chore_id: 0,
@@ -575,7 +569,6 @@ describe("Log", () => {
         new_value: "30",
       };
       client.getLog.mockResolvedValue([personEntry]);
-      setViewportWidth(1024);
       wrap(<Log />);
 
       await waitFor(() => {
@@ -594,176 +587,21 @@ describe("Log", () => {
         timestamp: "2026-04-20T12:00:00Z",
       };
       client.getLog.mockResolvedValue([personEntry]);
-      setViewportWidth(1024);
       wrap(<Log />);
 
       await waitFor(() => {
-        // "Alice" should appear as the target name (without the "Person: " prefix)
         expect(screen.getByText("Alice")).toBeInTheDocument();
       });
 
-      // The raw "Person: Alice" string should not be visible as a cell value
       expect(screen.queryByText("Person: Alice")).not.toBeInTheDocument();
     });
 
-    it("shows target type 'chore' for entries whose chore_name does not start with 'Person:'", async () => {
-      setViewportWidth(1024);
+    it("shows target type 'chore' badge in main row for entries whose chore_name does not start with 'Person:'", async () => {
       wrap(<Log />);
 
       await waitFor(() => {
         const choreBadges = screen.getAllByText("chore");
         expect(choreBadges.length).toBeGreaterThan(0);
-      });
-    });
-  });
-
-  describe("Responsive breakpoints (850px minimum for 5-column layout)", () => {
-    afterEach(() => {
-      setViewportWidth(1024); // Reset to desktop width
-    });
-
-    it("shows 3 column headers on mobile (<850px): Timestamp, Action, Target", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Action").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Target").length).toBeGreaterThan(0);
-        // Target Type, Actor, and Assignee columns are hidden on mobile
-        expect(screen.queryByText("Target Type")).not.toBeInTheDocument();
-        expect(screen.queryByText("Actor")).not.toBeInTheDocument();
-        expect(screen.queryByText("Assignee")).not.toBeInTheDocument();
-      });
-    });
-
-    it("hides Target Type column header on mobile (<850px)", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.queryByText("Target Type")).not.toBeInTheDocument();
-      });
-    });
-
-    it("hides Assignee column header on mobile (<850px)", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.queryByText("Assignee")).not.toBeInTheDocument();
-      });
-    });
-
-    it("hides Actor column header on mobile (<850px)", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        const vacuums = screen.getAllByText("Vacuum");
-        expect(vacuums.length).toBeGreaterThan(0);
-      });
-      // Verify Actor cells are not rendered on mobile
-      const aliceElements = screen.queryAllByText("Alice");
-      expect(aliceElements.length).toBe(0);
-    });
-
-    it("shows 3 column headers on tablet (between breakpoints, <850px): Timestamp, Action, Target", async () => {
-      setViewportWidth(600);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Action").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Target").length).toBeGreaterThan(0);
-        expect(screen.queryByText("Target Type")).not.toBeInTheDocument();
-        expect(screen.queryByText("Actor")).not.toBeInTheDocument();
-      });
-    });
-
-    it("hides Target Type on tablet (<850px)", async () => {
-      setViewportWidth(600);
-      wrap(<Log />);
-      await waitFor(() => {
-        const targetTypeHeaders = screen.queryAllByText("Target Type");
-        expect(targetTypeHeaders.length).toBe(0);
-      });
-    });
-
-    it("shows 6 column headers on desktop (>=850px): Timestamp, Action, Target Type, Actor, Assignee, Target", async () => {
-      setViewportWidth(1024);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.getAllByText("Timestamp").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Action").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Target Type").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Actor").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Assignee").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Target").length).toBeGreaterThan(0);
-      });
-    });
-
-    it("shows Target Type on desktop (>=850px)", async () => {
-      setViewportWidth(1024);
-      wrap(<Log />);
-      await waitFor(() => {
-        const targetTypeHeaders = screen.getAllByText("Target Type");
-        expect(targetTypeHeaders.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("shows Actor on desktop (>=850px)", async () => {
-      setViewportWidth(1024);
-      wrap(<Log />);
-      await waitFor(() => {
-        const alices = screen.getAllByText("Alice");
-        expect(alices.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("never shows Content column on any breakpoint", async () => {
-      for (const width of [375, 600, 1024]) {
-        vi.resetAllMocks();
-        client.getLog.mockResolvedValue(LOG_ENTRIES);
-        client.getPeople.mockResolvedValue(PEOPLE);
-        client.getChores.mockResolvedValue(CHORES);
-
-        setViewportWidth(width);
-        const { unmount } = wrap(<Log />);
-        await waitFor(() => {
-          const contentHeader = screen.queryByText("Content");
-          expect(contentHeader).not.toBeInTheDocument();
-        });
-        unmount();
-      }
-    });
-
-    it("formats timestamp as time-only on mobile (<850px)", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        const timestamps = screen.getAllByText(/\d{1,2}:\d{2}/);
-        expect(timestamps.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("formats timestamp as full date on desktop (>=850px)", async () => {
-      setViewportWidth(1024);
-      wrap(<Log />);
-      await waitFor(() => {
-        // Check for presence of log entries with full rendering
-        const content = screen.getAllByText(/Vacuum|Alice|completed|skipped/);
-        expect(content.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("handles window resize from mobile (<850px) to desktop (>=850px)", async () => {
-      setViewportWidth(375);
-      wrap(<Log />);
-      await waitFor(() => {
-        expect(screen.queryByText("Target Type")).not.toBeInTheDocument();
-        expect(screen.queryByText("Actor")).not.toBeInTheDocument();
-      });
-
-      setViewportWidth(1024);
-      await waitFor(() => {
-        expect(screen.getAllByText("Target Type").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("Actor").length).toBeGreaterThan(0);
       });
     });
   });

--- a/frontend/src/components/Log.css
+++ b/frontend/src/components/Log.css
@@ -94,12 +94,12 @@
 }
 
 .log-table th {
-  padding: 0.75rem 1rem;
+  padding: 0.75rem 1.25rem;
   text-align: left;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 
@@ -130,31 +130,48 @@
 }
 
 .log-table td {
-  padding: 0.75rem 1rem;
+  padding: 1rem 1.25rem;
   color: var(--text);
 }
 
 .log-timestamp {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.875rem;
   white-space: nowrap;
-  width: 180px;
+  width: 100px;
+}
+
+.log-timestamp--aged {
+  color: rgba(var(--error-rgb), 0.7);
+}
+
+.log-target-type {
+  width: 90px;
+}
+
+.log-action {
+  width: 140px;
 }
 
 .log-actor {
   font-weight: 500;
-  width: 180px;
+  width: 160px;
 }
 
-.log-assignee {
+.log-target {
   font-weight: 500;
-  width: 180px;
 }
 
-.log-target-type {
-  width: 120px;
+.log-chevron {
+  width: 32px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  opacity: 0.5;
+  padding-right: 1rem;
 }
 
+/* Target type badge */
 .target-badge {
   display: inline-block;
   padding: 0.2rem 0.5rem;
@@ -166,38 +183,37 @@
   color: var(--text-muted);
 }
 
-.log-target {
-  font-weight: 500;
-}
-
-.log-action {
-  width: 100px;
-}
-
-.action-badge {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  border-radius: 4px;
-  color: var(--text);
-  font-weight: 600;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  border: 1px solid var(--border);
-}
-
-/* Semantic action colors */
-.action-badge--completed  { border-color: var(--success); color: var(--success); }
-.action-badge--created    { border-color: var(--success); color: var(--success); }
-.action-badge--skipped    { border-color: var(--warning); color: var(--warning); }
-.action-badge--marked_due { border-color: var(--warning); color: var(--warning); }
-.action-badge--deleted    { border-color: var(--error);   color: var(--error); }
-.action-badge--reassigned { border-color: var(--accent);  color: var(--accent); }
-.action-badge--updated    { border-color: var(--accent);  color: var(--accent); }
-
-/* Semantic target type colors */
 .target-badge--chore { border-color: var(--accent); color: var(--accent); }
 .target-badge--user  { border-color: var(--gold);   color: var(--gold); }
+
+/* Action badge — dot prefix + filled pill */
+.action-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.8rem;
+}
+
+.action-badge::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.action-badge--completed  { background: rgba(var(--success-rgb), 0.15); color: var(--success); }
+.action-badge--created    { background: rgba(var(--success-rgb), 0.15); color: var(--success); }
+.action-badge--skipped    { background: rgba(var(--warning-rgb), 0.15); color: var(--warning); }
+.action-badge--marked_due { background: rgba(var(--warning-rgb), 0.15); color: var(--warning); }
+.action-badge--deleted    { background: rgba(var(--error-rgb),   0.15); color: var(--error); }
+.action-badge--reassigned { background: rgba(var(--accent-rgb),  0.15); color: var(--accent); }
+.action-badge--updated    { background: rgba(var(--accent-rgb),  0.15); color: var(--accent); }
 
 /* Detail row — expands inline below the clicked row */
 .log-detail-row {
@@ -218,7 +234,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 1rem;
-  padding: 0.75rem 1rem;
+  padding: 0.75rem 1.25rem;
 }
 
 .detail-item {
@@ -283,9 +299,7 @@
   .action-icon {
     font-size: 1.5rem;
   }
-}
 
-@media (max-width: 768px) {
   .log-filters {
     grid-template-columns: 1fr;
   }
@@ -295,46 +309,35 @@
   }
 }
 
-/* Mobile/Tablet breakpoint: 850px minimum for comfortable 5-column display */
-@media (max-width: 849px) {
+@media (max-width: 600px) {
   .log-table {
     font-size: 0.85rem;
   }
 
   .log-table th,
   .log-table td {
-    padding: 0.5rem 0.75rem;
+    padding: 0.75rem 0.875rem;
   }
 
   .log-timestamp {
-    width: 100px;
     font-size: 0.8rem;
-  }
-
-  .log-action {
-    width: 80px;
+    width: 70px;
   }
 
   .log-target-type {
-    width: 100px;
+    width: 70px;
+  }
+
+  .log-action {
+    width: 110px;
   }
 
   .log-actor {
-    width: 150px;
-  }
-
-  .log-assignee {
-    width: 150px;
+    width: 120px;
   }
 
   .action-badge {
-    padding: 0.2rem 0.4rem;
-    font-size: 0.65rem;
-  }
-
-  .log-target {
-    flex: 1;
-    min-width: 100px;
-    overflow-wrap: break-word;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
   }
 }

--- a/frontend/src/components/Log.jsx
+++ b/frontend/src/components/Log.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { MdFilterList } from "react-icons/md";
@@ -7,41 +7,46 @@ import "./Log.css";
 
 const ACTIONS = ["completed", "skipped", "reassigned", "created", "deleted", "updated", "marked_due"];
 
+const ACTION_LABELS = {
+  completed: "Completed",
+  skipped: "Skipped",
+  reassigned: "Reassigned",
+  created: "Created",
+  deleted: "Deleted",
+  updated: "Updated",
+  marked_due: "Marked Due",
+};
+
 const PAGE_SIZE = 20;
 
-// Breakpoint detection (log table needs 850px to comfortably show 5 columns)
-const BREAKPOINT_MOBILE = 850;
+function formatRelativeTimestamp(timestamp) {
+  const diffMs = Date.now() - new Date(timestamp).getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHr = Math.floor(diffMs / 3600000);
+  const diffDay = Math.floor(diffMs / 86400000);
 
-function useBreakpoint() {
-  const [isMobile, setIsMobile] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth < BREAKPOINT_MOBILE;
-  });
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < BREAKPOINT_MOBILE);
-    };
-
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  return isMobile;
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${diffDay}d ago`;
 }
 
-function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
+function isAged(timestamp) {
+  return Date.now() - new Date(timestamp).getTime() >= 86400000;
+}
+
+function LogRow({ entry }) {
   const [expanded, setExpanded] = useState(false);
 
   const targetType = entry.chore_name.startsWith("Person:") ? "user" : "chore";
   const targetName = entry.chore_name.replace("Person: ", "");
   const actionClass = `action-badge action-badge--${entry.action}`;
-  const targetClass = `target-badge target-badge--${targetType}`;
+  const actionLabel = ACTION_LABELS[entry.action] || entry.action;
   const fullTimestamp = new Date(entry.timestamp).toLocaleString();
+  const relTimestamp = formatRelativeTimestamp(entry.timestamp);
+  const aged = isAged(entry.timestamp);
 
-  const handleClick = () => {
-    setExpanded((prev) => !prev);
-  };
+  const handleClick = () => setExpanded((prev) => !prev);
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -60,22 +65,18 @@ function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
         aria-expanded={expanded}
         style={expanded ? { display: "none" } : undefined}
       >
-        <td className="log-timestamp">{formatTimestamp(entry.timestamp)}</td>
-        <td className="log-action">
-          <span className={actionClass}>{entry.action}</span>
+        <td className={`log-timestamp${aged ? " log-timestamp--aged" : ""}`}>
+          {relTimestamp}
         </td>
-        {!isMobile && (
-          <td className="log-target-type">
-            <span className={targetClass}>{targetType}</span>
-          </td>
-        )}
-        {!isMobile && (
-          <td className="log-actor">{entry.person}</td>
-        )}
-        {!isMobile && (
-          <td className="log-assignee">{entry.assignee ?? ""}</td>
-        )}
+        <td className="log-target-type">
+          <span className={`target-badge target-badge--${targetType}`}>{targetType}</span>
+        </td>
+        <td className="log-action">
+          <span className={actionClass}>{actionLabel}</span>
+        </td>
+        <td className="log-actor">{entry.person}</td>
         <td className="log-target">{targetName}</td>
+        <td className="log-chevron">›</td>
       </tr>
 
       {expanded && (
@@ -86,7 +87,7 @@ function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
           tabIndex={0}
           aria-expanded={expanded}
         >
-          <td colSpan={colSpan} className="log-detail-cell">
+          <td colSpan={6} className="log-detail-cell">
             <div className="log-detail-content">
               <div className="detail-item">
                 <span className="detail-label">Timestamp</span>
@@ -94,13 +95,13 @@ function LogRow({ entry, isMobile, formatTimestamp, colSpan }) {
               </div>
 
               <div className="detail-item">
-                <span className="detail-label">Action</span>
-                <span className="detail-value">{entry.action}</span>
+                <span className="detail-label">Target Type</span>
+                <span className="detail-value">{targetType}</span>
               </div>
 
               <div className="detail-item">
-                <span className="detail-label">Target Type</span>
-                <span className="detail-value">{targetType}</span>
+                <span className="detail-label">Action</span>
+                <span className="detail-value">{actionLabel}</span>
               </div>
 
               <div className="detail-item">
@@ -159,7 +160,6 @@ export default function Log() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [page, setPage] = useState(0);
-  const isMobile = useBreakpoint();
 
   const filters = (() => {
     const f = {};
@@ -211,18 +211,6 @@ export default function Log() {
     setPage(0);
   };
 
-  const formatTimestamp = (timestamp) => {
-    const date = new Date(timestamp);
-    // On mobile, show time-only; on tablet/desktop, show full date and time
-    if (isMobile) {
-      return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-    }
-    return date.toLocaleString();
-  };
-
-  // Number of visible columns (for colSpan on detail rows)
-  const colSpan = isMobile ? 3 : 6;
-
   return (
     <div className="log">
       <div className="page-header">
@@ -238,81 +226,81 @@ export default function Log() {
       </div>
 
       {filtersExpanded && (
-      <div className="log-filters">
-        <div className="filter-group">
-          <label htmlFor="filter-person">Filter by person</label>
-          <select
-            id="filter-person"
-            value={searchParams.get("person") || ""}
-            onChange={(e) => handleFilterChange("person", e.target.value)}
-          >
-            <option value="">All people</option>
-            <option value="system">System</option>
-            <option value="schedule">Schedule</option>
-            {people.map((p) => (
-              <option key={p.id} value={p.name}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-        </div>
+        <div className="log-filters">
+          <div className="filter-group">
+            <label htmlFor="filter-person">Filter by person</label>
+            <select
+              id="filter-person"
+              value={searchParams.get("person") || ""}
+              onChange={(e) => handleFilterChange("person", e.target.value)}
+            >
+              <option value="">All people</option>
+              <option value="system">System</option>
+              <option value="schedule">Schedule</option>
+              {people.map((p) => (
+                <option key={p.id} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="filter-group">
-          <label htmlFor="filter-chore">Filter by chore</label>
-          <select
-            id="filter-chore"
-            value={searchParams.get("chore_id") || ""}
-            onChange={(e) => handleFilterChange("chore_id", e.target.value)}
-          >
-            <option value="">All chores</option>
-            {chores.map((c) => (
-              <option key={c.unique_id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-        </div>
+          <div className="filter-group">
+            <label htmlFor="filter-chore">Filter by chore</label>
+            <select
+              id="filter-chore"
+              value={searchParams.get("chore_id") || ""}
+              onChange={(e) => handleFilterChange("chore_id", e.target.value)}
+            >
+              <option value="">All chores</option>
+              {chores.map((c) => (
+                <option key={c.unique_id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="filter-group">
-          <label htmlFor="filter-action">Filter by action</label>
-          <select
-            id="filter-action"
-            value={searchParams.get("action") || ""}
-            onChange={(e) => handleFilterChange("action", e.target.value)}
-          >
-            <option value="">All actions</option>
-            {ACTIONS.map((a) => (
-              <option key={a} value={a}>
-                {a.charAt(0).toUpperCase() + a.slice(1)}
-              </option>
-            ))}
-          </select>
-        </div>
+          <div className="filter-group">
+            <label htmlFor="filter-action">Filter by action</label>
+            <select
+              id="filter-action"
+              value={searchParams.get("action") || ""}
+              onChange={(e) => handleFilterChange("action", e.target.value)}
+            >
+              <option value="">All actions</option>
+              {ACTIONS.map((a) => (
+                <option key={a} value={a}>
+                  {ACTION_LABELS[a] || a}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="filter-group">
-          <label htmlFor="filter-start-date">Start date</label>
-          <input
-            id="filter-start-date"
-            type="date"
-            value={searchParams.get("start_date") || ""}
-            onChange={(e) => handleFilterChange("start_date", e.target.value)}
-          />
-        </div>
+          <div className="filter-group">
+            <label htmlFor="filter-start-date">Start date</label>
+            <input
+              id="filter-start-date"
+              type="date"
+              value={searchParams.get("start_date") || ""}
+              onChange={(e) => handleFilterChange("start_date", e.target.value)}
+            />
+          </div>
 
-        <div className="filter-group">
-          <label htmlFor="filter-end-date">End date</label>
-          <input
-            id="filter-end-date"
-            type="date"
-            value={searchParams.get("end_date") || ""}
-            onChange={(e) => handleFilterChange("end_date", e.target.value)}
-          />
-        </div>
+          <div className="filter-group">
+            <label htmlFor="filter-end-date">End date</label>
+            <input
+              id="filter-end-date"
+              type="date"
+              value={searchParams.get("end_date") || ""}
+              onChange={(e) => handleFilterChange("end_date", e.target.value)}
+            />
+          </div>
 
-        <button className="btn-secondary" onClick={handleClearFilters}>
-          Clear filters
-        </button>
-      </div>
+          <button className="btn-secondary" onClick={handleClearFilters}>
+            Clear filters
+          </button>
+        </div>
       )}
 
       <div className="log-entries">
@@ -326,22 +314,16 @@ export default function Log() {
               <thead>
                 <tr>
                   <th>Timestamp</th>
+                  <th>Target Type</th>
                   <th>Action</th>
-                  {!isMobile && <th>Target Type</th>}
-                  {!isMobile && <th>Actor</th>}
-                  {!isMobile && <th>Assignee</th>}
+                  <th>Actor</th>
                   <th>Target</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
                 {logEntries.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((entry) => (
-                  <LogRow
-                    key={entry.id}
-                    entry={entry}
-                    isMobile={isMobile}
-                    formatTimestamp={formatTimestamp}
-                    colSpan={colSpan}
-                  />
+                  <LogRow key={entry.id} entry={entry} />
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary

- Replace absolute timestamps with relative format (Xm/Xh/Xd ago); entries >24h old render in muted warm tone
- Redesign action badges from bordered outlines to dot-prefix filled pills with semantic colors (green/yellow/red/blue)
- Expand main table to five columns: Timestamp, Target Type, Action, Actor, Target + chevron expand indicator
- Reorder expanded detail card to match table column sequence (Timestamp → Target Type → Action → Actor → Target → optional fields)
- Remove `isMobile` breakpoint logic; update test suite to reflect new layout and timestamp format

## Test plan

- [x] All 35 Log component tests pass
- [x] Filters (person, chore, action, date range) still function correctly
- [x] Expandable detail rows show full entry data in correct order
- [x] Relative timestamps render for all test entries
- [x] Target type badges visible in main table rows
- [x] Docker containers rebuild and serve updated frontend

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)