### PR TITLE
fix: restore package.json and switch release-type to node

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "release-type": "simple",
+      "release-type": "node",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "prerelease-type": "pre",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,1 +1,35 @@
-1.5.0
+{
+  "name": "chores-web",
+  "version": "1.5.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^9.0.0",
+    "@mui/x-date-pickers": "^9.0.2",
+    "@tanstack/react-query": "^5.40.0",
+    "dayjs": "^1.11.20",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.6.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^24.1.0",
+    "vite": "^5.3.1",
+    "vitest": "^1.6.0"
+  }
+}


### PR DESCRIPTION
## Summary

- `frontend/package.json` was overwritten with a bare version string by release-please `simple` release-type — restored to full package.json
- Switched `release-type` from `simple` to `node` in release-please config to prevent recurrence

## Test plan

- [ ] Verify `frontend/package.json` contains correct structure
- [ ] Verify next release-please run preserves `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)