### PR TITLE
fix: sync backend APP_VERSION and prevent stale version in DB

### DIFF
--- a/.claude/skills/docker-rebuild/SKILL.md
+++ b/.claude/skills/docker-rebuild/SKILL.md
@@ -3,4 +3,4 @@ name: docker-rebuild
 description: Rebuild a Docker image from a Dockerfile. Run this when you are going to ask the user to "approve to commit and PR, or request changes" after completing a task, or when the user asks for "docker rebuild".
 ---
 
-Run `bash .claude/skills/docker-rebuild/rebuild.sh` to rebuild the Docker image from the Dockerfile. This is typically done after completing an implementation task, before asking the user to approve for commit and PR, or when the user explicitly requests a "docker rebuild".
+Run `bash .claude/skills/docker-rebuild/script.sh` to rebuild the Docker image from the Dockerfile. This is typically done after completing an implementation task, before asking the user to approve for commit and PR, or when the user explicitly requests a "docker rebuild".

--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -7,7 +7,13 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "prerelease-type": "pre",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "backend/app/config.py"
+        }
+      ]
     }
   },
   "changelog-sections": [

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,7 @@
 from pydantic_settings import BaseSettings
 
 # Current application version
-APP_VERSION = "1.2.0"
+APP_VERSION = "1.5.1"
 
 
 class Settings(BaseSettings):

--- a/backend/app/services/update_check_service.py
+++ b/backend/app/services/update_check_service.py
@@ -69,6 +69,9 @@ async def check_for_updates(db: AsyncSession) -> Optional[str]:
         )
         db.add(update_check)
         await db.commit()
+    elif update_check.current_version != APP_VERSION:
+        update_check.current_version = APP_VERSION
+        await db.commit()
 
     # Check if enough time has passed since last check
     if update_check.last_checked_at:
@@ -106,6 +109,9 @@ async def get_update_status(db: AsyncSession) -> dict:
             check_interval_hours=24,
         )
         db.add(update_check)
+        await db.commit()
+    elif update_check.current_version != APP_VERSION:
+        update_check.current_version = APP_VERSION
         await db.commit()
 
     # Determine if update is available

--- a/backend/tests/test_update_check_service.py
+++ b/backend/tests/test_update_check_service.py
@@ -119,10 +119,10 @@ async def test_check_for_updates_skips_if_disabled(db: AsyncSession):
 @pytest.mark.asyncio
 async def test_version_comparison_identifies_update(db: AsyncSession):
     """Test that version comparison correctly identifies when update is available."""
-    # Create record with older version
+    # Create record with a latest_version newer than APP_VERSION
     update_check = UpdateCheck(
         current_version="1.0.0",
-        latest_version="1.1.0",
+        latest_version="99.0.0",
         check_enabled=True,
         check_interval_hours=24,
     )


### PR DESCRIPTION
## Summary

- `APP_VERSION` in `backend/app/config.py` was hardcoded to `1.2.0` while `frontend/package.json` was at `1.5.1` — release-please only bumped the frontend
- `update_check_service` never updated the DB `current_version` field after an upgrade, causing stale comparisons
- Added `backend/app/config.py` to release-please `extra-files` so future releases stay in sync automatically

## Test plan

- [ ] Settings → About shows `v1.5.1` as current version
- [ ] Update available indicator reflects correct comparison (no false positive)
- [ ] Next release-please PR bumps version in both `frontend/package.json` and `backend/app/config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)