### PR TITLE
fix: correct points log edits adjusting person totals (#215)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from .database import engine
 from .models import Base
 from .routers import auth, chores, people, points, log, config, theme, export, data_import, status, admin_db
 from .services.scheduler import start_scheduler, stop_scheduler
-from .services.chore_service import transition_overdue_chores
+from .services.chore_service import transition_overdue_chores, normalize_points_log_persons
 from .database import AsyncSessionLocal
 from .migrations import apply_migrations
 
@@ -28,6 +28,7 @@ async def lifespan(app: FastAPI):
     # Apply database migrations
     async with AsyncSessionLocal() as db:
         await apply_migrations(db)
+        await normalize_points_log_persons(db)
         await transition_overdue_chores(db)
 
     start_scheduler()

--- a/backend/app/routers/admin_db.py
+++ b/backend/app/routers/admin_db.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database import get_db
@@ -59,29 +59,31 @@ async def update_points_log(
     old_points = row.points
     old_person_name = row.person
 
-    # --- apply points delta to Person ---
-    delta = body.points - old_points
-    if delta != 0:
-        person_result = await db.execute(
-            select(Person).where(Person.name == old_person_name)
-        )
-        person_obj = person_result.scalar_one_or_none()
-        if person_obj is not None:
-            person_obj.points = max(0, person_obj.points + delta)
+    def _person_lookup(name: str):
+        """Match by username or display name — handles legacy rows that stored display name."""
+        return or_(Person.username == name, Person.name == name)
 
-    # If person name changed, rebalance both sides
-    if body.person != old_person_name:
-        # Remove old points from old person
+    if body.person == old_person_name:
+        # Same person — apply delta only
+        delta = body.points - old_points
+        if delta != 0:
+            person_result = await db.execute(
+                select(Person).where(_person_lookup(old_person_name))
+            )
+            person_obj = person_result.scalar_one_or_none()
+            if person_obj is not None:
+                person_obj.points = max(0, person_obj.points + delta)
+    else:
+        # Person changed — rebalance both sides (no delta block to avoid double-adjustment)
         old_person_result = await db.execute(
-            select(Person).where(Person.name == old_person_name)
+            select(Person).where(_person_lookup(old_person_name))
         )
         old_person_obj = old_person_result.scalar_one_or_none()
         if old_person_obj is not None:
             old_person_obj.points = max(0, old_person_obj.points - old_points)
 
-        # Add new points to new person
         new_person_result = await db.execute(
-            select(Person).where(Person.name == body.person)
+            select(Person).where(_person_lookup(body.person))
         )
         new_person_obj = new_person_result.scalar_one_or_none()
         if new_person_obj is not None:
@@ -133,7 +135,7 @@ async def delete_points_log(
 
     # Reverse points on person (floor at 0)
     person_result = await db.execute(
-        select(Person).where(Person.name == row.person)
+        select(Person).where(or_(Person.username == row.person, Person.name == row.person))
     )
     person_obj = person_result.scalar_one_or_none()
     if person_obj is not None:

--- a/backend/app/services/chore_service.py
+++ b/backend/app/services/chore_service.py
@@ -4,7 +4,7 @@ import re
 from datetime import date, datetime, timezone
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Chore, PointsLog, ChoreLog, Person
@@ -17,6 +17,26 @@ CHANGE_FORCED_DUE = "forced_due"
 CHANGE_MARKED_DUE = "marked_due"
 CHANGE_CREATED = "created"
 CHANGE_DELETED = "deleted"
+
+
+async def normalize_points_log_persons(db: AsyncSession) -> None:
+    """Normalize legacy PointsLog.person values from display name to username.
+
+    Old completions stored the person's display name (e.g. 'Derek').
+    New completions store the username (e.g. 'derek').
+    This runs at startup to bring all entries in line with the username convention.
+    Idempotent: safe to run on every startup.
+    """
+    people_result = await db.execute(select(Person))
+    people = people_result.scalars().all()
+    for person in people:
+        if person.name != person.username:
+            await db.execute(
+                update(PointsLog)
+                .where(PointsLog.person == person.name)
+                .values(person=person.username)
+            )
+    await db.commit()
 
 
 def _slugify(name: str) -> str:

--- a/backend/tests/test_admin_db.py
+++ b/backend/tests/test_admin_db.py
@@ -43,7 +43,7 @@ async def _make_normal_user(db: AsyncSession, username: str = "user", password: 
 
 async def _make_points_log(
     db: AsyncSession,
-    person_name: str = "Alice",
+    person_name: str = "alice",
     points: int = 10,
     chore_id: int = 1,
 ) -> PointsLog:
@@ -145,12 +145,12 @@ class TestUpdatePointsLog:
         db.add(person)
         await db.commit()
 
-        row = await _make_points_log(db, person_name="Alice", points=10)
+        row = await _make_points_log(db, person_name="alice", points=10)
 
         token = await _token(client, "admin", "adminpass")
         r = await client.patch(
             f"/admin/db/points-log/{row.id}",
-            json={"points": 7, "person": "Alice"},
+            json={"points": 7, "person": "alice"},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert r.status_code == 200
@@ -164,12 +164,12 @@ class TestUpdatePointsLog:
     @pytest.mark.asyncio
     async def test_update_writes_audit_log(self, client: AsyncClient, db: AsyncSession):
         await _make_admin(db)
-        row = await _make_points_log(db, person_name="Alice", points=5)
+        row = await _make_points_log(db, person_name="alice", points=5)
 
         token = await _token(client, "admin", "adminpass")
         await client.patch(
             f"/admin/db/points-log/{row.id}",
-            json={"points": 3, "person": "Alice"},
+            json={"points": 3, "person": "alice"},
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -207,6 +207,111 @@ class TestUpdatePointsLog:
         )
         assert r.status_code == 403
 
+    @pytest.mark.asyncio
+    async def test_update_delta_path_uses_username(self, client: AsyncClient, db: AsyncSession):
+        """Points-only change: lookup must use Person.username, not Person.name."""
+        await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=10)
+        db.add(person)
+        await db.commit()
+
+        # PointsLog stores username (not display name)
+        row = await _make_points_log(db, person_name="alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 7, "person": "alice"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        await db.refresh(person)
+        assert person.points == 7  # 10 + (7-10) = 7
+
+    @pytest.mark.asyncio
+    async def test_update_reassigns_person_adjusts_both_points(self, client: AsyncClient, db: AsyncSession):
+        """Reassign to different person (same points): old loses, new gains."""
+        await _make_admin(db)
+        alice = Person(name="Alice", username="alice", password_hash="x", points=10)
+        bob = Person(name="Bob", username="bob", password_hash="x", points=0)
+        db.add(alice)
+        db.add(bob)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 10, "person": "bob"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        await db.refresh(alice)
+        await db.refresh(bob)
+        assert alice.points == 0   # lost 10
+        assert bob.points == 10    # gained 10
+
+    @pytest.mark.asyncio
+    async def test_update_person_and_points_simultaneously(self, client: AsyncClient, db: AsyncSession):
+        """Change both person and points: old loses old_points, new gains new_points (no double-delta)."""
+        await _make_admin(db)
+        alice = Person(name="Alice", username="alice", password_hash="x", points=10)
+        bob = Person(name="Bob", username="bob", password_hash="x", points=0)
+        db.add(alice)
+        db.add(bob)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 5, "person": "bob"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        await db.refresh(alice)
+        await db.refresh(bob)
+        assert alice.points == 0   # lost exactly old_points=10 (not double-adjusted)
+        assert bob.points == 5     # gained new_points=5
+
+    @pytest.mark.asyncio
+    async def test_update_missing_person_silently_skips(self, client: AsyncClient, db: AsyncSession):
+        """Reassign to unknown username: update succeeds, no crash."""
+        await _make_admin(db)
+        row = await _make_points_log(db, person_name="ghost", points=5)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 5, "person": "ghost"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_update_legacy_display_name_in_log(self, client: AsyncClient, db: AsyncSession):
+        """Old PointsLog rows storing display name (not username) still get points adjusted."""
+        await _make_admin(db)
+        # Person has display name 'Alice', username 'alice'
+        person = Person(name="Alice", username="alice", password_hash="x", points=10)
+        db.add(person)
+        await db.commit()
+
+        # Old-style row: person stored as display name, not username
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.patch(
+            f"/admin/db/points-log/{row.id}",
+            json={"points": 6, "person": "Alice"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        await db.refresh(person)
+        assert person.points == 6  # 10 + (6-10) = 6
+
 
 # ---------------------------------------------------------------------------
 # Tests: delete (DELETE)
@@ -216,12 +321,11 @@ class TestDeletePointsLog:
     @pytest.mark.asyncio
     async def test_admin_can_delete(self, client: AsyncClient, db: AsyncSession):
         await _make_admin(db)
-        Person(name="Alice", username="alice", password_hash="x", points=10)
         person = Person(name="Alice", username="alice", password_hash="x", points=10)
         db.add(person)
         await db.commit()
 
-        row = await _make_points_log(db, person_name="Alice", points=10)
+        row = await _make_points_log(db, person_name="alice", points=10)
 
         token = await _token(client, "admin", "adminpass")
         r = await client.delete(
@@ -242,7 +346,7 @@ class TestDeletePointsLog:
         db.add(person)
         await db.commit()
 
-        row = await _make_points_log(db, person_name="Alice", points=10)
+        row = await _make_points_log(db, person_name="alice", points=10)
 
         token = await _token(client, "admin", "adminpass")
         await client.delete(
@@ -260,7 +364,7 @@ class TestDeletePointsLog:
         db.add(person)
         await db.commit()
 
-        row = await _make_points_log(db, person_name="Alice", points=10)
+        row = await _make_points_log(db, person_name="alice", points=10)
 
         token = await _token(client, "admin", "adminpass")
         await client.delete(
@@ -274,7 +378,7 @@ class TestDeletePointsLog:
     @pytest.mark.asyncio
     async def test_delete_writes_audit_log(self, client: AsyncClient, db: AsyncSession):
         await _make_admin(db)
-        row = await _make_points_log(db, person_name="Alice", points=5)
+        row = await _make_points_log(db, person_name="alice", points=5)
 
         token = await _token(client, "admin", "adminpass")
         await client.delete(
@@ -299,6 +403,45 @@ class TestDeletePointsLog:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_reverses_points_uses_username(self, client: AsyncClient, db: AsyncSession):
+        """Delete must look up Person by username, not display name."""
+        await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=15)
+        db.add(person)
+        await db.commit()
+
+        row = await _make_points_log(db, person_name="alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 204
+        await db.refresh(person)
+        assert person.points == 5  # 15 - 10
+
+    @pytest.mark.asyncio
+    async def test_delete_legacy_display_name_in_log(self, client: AsyncClient, db: AsyncSession):
+        """Old PointsLog rows storing display name still reverse points on delete."""
+        await _make_admin(db)
+        person = Person(name="Alice", username="alice", password_hash="x", points=15)
+        db.add(person)
+        await db.commit()
+
+        # Old-style row: person stored as display name
+        row = await _make_points_log(db, person_name="Alice", points=10)
+
+        token = await _token(client, "admin", "adminpass")
+        r = await client.delete(
+            f"/admin/db/points-log/{row.id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 204
+        await db.refresh(person)
+        assert person.points == 5  # 15 - 10
 
     @pytest.mark.asyncio
     async def test_non_admin_cannot_delete(self, client: AsyncClient, db: AsyncSession):

--- a/backend/tests/test_points_normalization.py
+++ b/backend/tests/test_points_normalization.py
@@ -1,0 +1,134 @@
+"""Tests for points_log person normalization and stats endpoint with username routing."""
+import pytest
+from datetime import datetime, timezone
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Person, PointsLog, Settings
+from app.security import hash_password
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _make_person(db: AsyncSession, name: str, username: str, points: int = 0) -> Person:
+    person = Person(
+        name=name,
+        username=username,
+        password_hash=hash_password("pass"),
+        is_admin=False,
+        points=points,
+    )
+    db.add(person)
+    await db.commit()
+    await db.refresh(person)
+    return person
+
+
+async def _make_admin(db: AsyncSession) -> Person:
+    db.add(Settings(key="auth_enabled", value="true"))
+    person = Person(
+        name="Admin",
+        username="admin",
+        password_hash=hash_password("adminpass"),
+        is_admin=True,
+        points=0,
+    )
+    db.add(person)
+    await db.commit()
+    await db.refresh(person)
+    return person
+
+
+async def _make_points_log(db: AsyncSession, person_name: str, points: int) -> PointsLog:
+    row = PointsLog(
+        person=person_name,
+        points=points,
+        chore_id=1,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def _token(client: AsyncClient, username: str = "admin", password: str = "adminpass") -> str:
+    r = await client.post("/auth/login", json={"username": username, "password": password})
+    return r.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: normalize_points_log_persons
+# ---------------------------------------------------------------------------
+
+class TestNormalizePointsLogPersons:
+    @pytest.mark.asyncio
+    async def test_normalizes_display_name_to_username(self, db: AsyncSession):
+        """Legacy entries storing display name are updated to username."""
+        from app.services.chore_service import normalize_points_log_persons
+
+        person = await _make_person(db, name="Derek", username="derek")
+        # Legacy entry: person stored as display name
+        row = await _make_points_log(db, person_name="Derek", points=5)
+
+        await normalize_points_log_persons(db)
+
+        await db.refresh(row)
+        assert row.person == "derek"  # normalized to username
+
+    @pytest.mark.asyncio
+    async def test_skips_already_normalized_entries(self, db: AsyncSession):
+        """Entries already using username are untouched."""
+        from app.services.chore_service import normalize_points_log_persons
+
+        person = await _make_person(db, name="Derek", username="derek")
+        row = await _make_points_log(db, person_name="derek", points=5)
+
+        await normalize_points_log_persons(db)
+
+        await db.refresh(row)
+        assert row.person == "derek"
+
+    @pytest.mark.asyncio
+    async def test_normalizes_multiple_people(self, db: AsyncSession):
+        """All people with display-name entries get normalized."""
+        from app.services.chore_service import normalize_points_log_persons
+
+        await _make_person(db, name="Derek", username="derek")
+        await _make_person(db, name="Amy", username="amy")
+        row1 = await _make_points_log(db, person_name="Derek", points=3)
+        row2 = await _make_points_log(db, person_name="Amy", points=2)
+        row3 = await _make_points_log(db, person_name="amy", points=1)  # already normalized
+
+        await normalize_points_log_persons(db)
+
+        await db.refresh(row1)
+        await db.refresh(row2)
+        await db.refresh(row3)
+        assert row1.person == "derek"
+        assert row2.person == "amy"
+        assert row3.person == "amy"  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Tests: /points/stats/{username} returns combined totals
+# ---------------------------------------------------------------------------
+
+class TestStatsEndpointByUsername:
+    @pytest.mark.asyncio
+    async def test_stats_returns_total_for_username(self, client: AsyncClient, db: AsyncSession):
+        """Stats endpoint called with username returns correct total."""
+        await _make_admin(db)
+        await _make_person(db, name="Derek", username="derek")
+        await _make_points_log(db, person_name="derek", points=5)
+        await _make_points_log(db, person_name="derek", points=3)
+
+        token = await _token(client)
+        r = await client.get("/points/stats/derek", headers={"Authorization": f"Bearer {token}"})
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_points"] == 8
+        assert data["name"] == "Derek"  # display name in response

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -445,16 +445,26 @@ graph TB
 
 - **Award:** Chore completion = Chore.points awarded to person
 - **Tracking:** PointsLog record created with (person, points, chore_id, completed_at)
-- **Aggregation:** Person.points = sum of all PointsLog entries for that person
+- **Aggregation:** Person.points maintained as running total; incremented on completion, adjusted on admin edit/delete
 - **Goals:** Rolling 7-day and 30-day windows calculated from PointsLog timestamps
 - **Reset:** Goals reset automatically at week/month boundaries based on completed_at timestamps
 
 ### Models
 
-- **Person.points** – Total lifetime points (sum of all PointsLog)
+- **Person.points** – Total lifetime points (running total, floor 0)
 - **Person.goal_7d** – Target points for 7-day rolling window
 - **Person.goal_30d** – Target points for 30-day rolling window
 - **PointsLog** – Transaction log: (id, person, points, chore_id, completed_at)
+  - `person` stores **username** (not display name)
+
+### Admin Points Log Management
+
+When an admin edits or deletes a PointsLog entry via `PATCH /admin/db/points-log/{id}` or `DELETE /admin/db/points-log/{id}`, `Person.points` is adjusted to maintain consistency:
+
+- **Points change only** (same person): `Person.points` adjusted by delta (`new - old`), floored at 0
+- **Person reassignment** (different person, points same or changed): old person loses `old_points`, new person gains `new_points` — no double adjustment
+- **Delete**: person loses the log's points, floored at 0
+- **Missing person**: if the username has no matching `Person` row, that side's adjustment is silently skipped; operation still succeeds
 
 ## Deployment Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -443,19 +443,20 @@ graph TB
 
 ### Point Calculation
 
-- **Award:** Chore completion = Chore.points awarded to person
-- **Tracking:** PointsLog record created with (person, points, chore_id, completed_at)
-- **Aggregation:** Person.points maintained as running total; incremented on completion, adjusted on admin edit/delete
+- **Award:** Chore completion = Chore.points awarded to person (by username)
+- **Tracking:** PointsLog record created with (person=username, points, chore_id, completed_at)
+- **Display:** `display_points = sum(PointsLog.points for person) - points_redeemed` — computed live from PointsLog
+- **Person.points:** Running total kept in sync with PointsLog; incremented on completion, adjusted on admin edit/delete
 - **Goals:** Rolling 7-day and 30-day windows calculated from PointsLog timestamps
-- **Reset:** Goals reset automatically at week/month boundaries based on completed_at timestamps
 
 ### Models
 
-- **Person.points** – Total lifetime points (running total, floor 0)
+- **Person.points** – Running total (floor 0); kept in sync with PointsLog sum
 - **Person.goal_7d** – Target points for 7-day rolling window
 - **Person.goal_30d** – Target points for 30-day rolling window
 - **PointsLog** – Transaction log: (id, person, points, chore_id, completed_at)
   - `person` stores **username** (not display name)
+  - Legacy entries with display name are normalized to username at startup
 
 ### Admin Points Log Management
 
@@ -464,7 +465,8 @@ When an admin edits or deletes a PointsLog entry via `PATCH /admin/db/points-log
 - **Points change only** (same person): `Person.points` adjusted by delta (`new - old`), floored at 0
 - **Person reassignment** (different person, points same or changed): old person loses `old_points`, new person gains `new_points` — no double adjustment
 - **Delete**: person loses the log's points, floored at 0
-- **Missing person**: if the username has no matching `Person` row, that side's adjustment is silently skipped; operation still succeeds
+- **Person lookup**: matched by username or display name — handles any legacy entries not yet normalized
+- **Missing person**: if no matching `Person` row found, that side's adjustment is silently skipped; operation still succeeds
 
 ## Deployment Architecture
 

--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -108,7 +108,7 @@ describe("Dashboard", () => {
     fireEvent.click(aliceCard);
 
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/users/Alice");
+      expect(screen.getByTestId("location")).toHaveTextContent("/users/alice");
     });
   });
 });

--- a/frontend/src/components/DatabaseSection.jsx
+++ b/frontend/src/components/DatabaseSection.jsx
@@ -43,6 +43,8 @@ export default function DatabaseSection() {
       updateAdminPointsLog(id, { points: Number(points), person }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-points-log"] });
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      queryClient.invalidateQueries({ queryKey: ["user-stats"] });
       triggerRowSuccess();
       setError(null);
       setTimeout(() => setEditId(null), getRowCloseDelay());
@@ -57,6 +59,8 @@ export default function DatabaseSection() {
     mutationFn: (id) => deleteAdminPointsLog(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-points-log"] });
+      queryClient.invalidateQueries({ queryKey: ["people"] });
+      queryClient.invalidateQueries({ queryKey: ["user-stats"] });
       setDeleteTarget(null);
       setSuccess("Entry deleted.");
       setError(null);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -45,7 +45,7 @@ export default function Dashboard() {
         {people.map((person) => (
           <div
             key={person.name}
-            onClick={() => navigate(`/users/${encodeURIComponent(person.name)}`)}
+            onClick={() => navigate(`/users/${encodeURIComponent(person.username)}`)}
             style={{ cursor: "pointer" }}
           >
             <UserCard

--- a/frontend/src/pages/UserDetail.jsx
+++ b/frontend/src/pages/UserDetail.jsx
@@ -31,7 +31,7 @@ export default function UserDetail() {
   });
 
   const personId = useMemo(() => {
-    const person = people.find((p) => p.name === userName);
+    const person = people.find((p) => p.username === userName);
     return person?.id;
   }, [people, userName]);
 


### PR DESCRIPTION
## Summary

- Fix `admin_db.py` using `Person.name` instead of `Person.username` for all four Person lookups in `update_points_log` and `delete_points_log` — lookups silently returned `None`, so no adjustment was made
- Fix double-delta bug: when person and points both changed in one edit, old person received two adjustments; blocks are now mutually exclusive
- Add `normalize_points_log_persons()` at startup to migrate legacy `PointsLog.person` values from display name to username, fixing split totals on the stats/user-detail pages
- Fix frontend routing to use `person.username` (not `person.name`) in `/users/:username` URLs so stats endpoints receive the correct identifier
- Invalidate `["user-stats"]` cache in `DatabaseSection` after admin edits/deletes so UI reflects changes immediately
- Add 7 new backend tests covering username lookup, reassignment, simultaneous person+points change, legacy display-name entries, and normalization function

## Deviations from implementation plan

Plan was backend-only. Two additional fixes required:
- Frontend URL routing (`Dashboard.jsx`, `UserDetail.jsx`) — stats endpoint was called with display name, only found legacy data
- `DatabaseSection.jsx` cache invalidation — UI showed stale totals after edits without page refresh

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)