### PR TITLE
feat: chores page layout changes (#266)

### DIFF
--- a/frontend/src/__tests__/ChoreList.test.jsx
+++ b/frontend/src/__tests__/ChoreList.test.jsx
@@ -219,6 +219,28 @@ describe("ChoreList", () => {
     });
   });
 
+  it("injects invisible spacer between last due and first complete chore", async () => {
+    const mixed = [
+      { id: "a", unique_id: "a", name: "Alpha", points: 1, state: "due", disabled: false,
+        current_assignee: null, schedule_summary: "Weekly", assignment_type: "open", next_due: "2026-05-01" },
+      { id: "b", unique_id: "b", name: "Beta", points: 2, state: "complete", disabled: false,
+        current_assignee: null, schedule_summary: "Weekly", assignment_type: "open", next_due: "2026-05-10" },
+    ];
+    client.getChores.mockResolvedValue(mixed);
+    wrap(<ChoreList />);
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    const list = screen.getByRole("region");
+    const spacer = list.querySelector(".chore-state-spacer");
+    expect(spacer).toBeInTheDocument();
+  });
+
+  it("does not inject spacer when all chores have the same state", async () => {
+    wrap(<ChoreList />); // all CHORES are state=due
+    await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+    const list = screen.getByRole("region");
+    expect(list.querySelector(".chore-state-spacer")).not.toBeInTheDocument();
+  });
+
   it("sorts chores by next due date with tied dates by name and no-date chores last", async () => {
     wrap(<ChoreList />);
 

--- a/frontend/src/__tests__/Chores.test.jsx
+++ b/frontend/src/__tests__/Chores.test.jsx
@@ -139,8 +139,10 @@ function wrap(ui, { initialEntries = ["/chores"] } = {}) {
 describe("Manage page", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    localStorage.clear();
     client.getChores.mockResolvedValue(CHORES);
     client.getPeople.mockResolvedValue(PEOPLE);
+    client.getPointsSummary.mockResolvedValue([]);
     client.createChore.mockResolvedValue({ ...CHORES[0], unique_id: "new_chore", name: "New Chore" });
     client.updateChore.mockResolvedValue({ ...CHORES[0], points: 10 });
     client.deleteChore.mockResolvedValue(null);
@@ -424,7 +426,7 @@ describe("Manage page", () => {
       return nameElement?.textContent || "";
     });
 
-    expect(choreNames).toEqual(["Bathroom", "Trash", "Vacuum", "Countertops", "Dishes", "Laundry"]);
+    expect(choreNames).toEqual(["Bathroom", "Trash", "Vacuum", "Countertops", "Laundry", "Dishes"]);
   });
 
   it("preserves due-date ordering after filters are applied", async () => {
@@ -621,6 +623,50 @@ describe("Manage page", () => {
     await waitFor(() => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
       expect(screen.queryByText("Laundry")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("stats section toggle", () => {
+    it("renders stats header with a toggle button", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.getByRole("button", { name: /toggle stats/i })).toBeInTheDocument();
+    });
+
+    it("shows stat cards by default (expanded)", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.getByText("Chores")).toBeInTheDocument();
+      expect(screen.getByText("Total Points")).toBeInTheDocument();
+    });
+
+    it("hides stat cards when toggle is clicked", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /toggle stats/i }));
+      expect(screen.queryByText("Total Points")).not.toBeInTheDocument();
+    });
+
+    it("restores stat cards when toggle is clicked again", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /toggle stats/i }));
+      fireEvent.click(screen.getByRole("button", { name: /toggle stats/i }));
+      expect(screen.getByText("Total Points")).toBeInTheDocument();
+    });
+
+    it("persists collapsed state to localStorage", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /toggle stats/i }));
+      expect(localStorage.getItem("chores-stats-expanded")).toBe("false");
+    });
+
+    it("starts collapsed when localStorage says collapsed", async () => {
+      localStorage.setItem("chores-stats-expanded", "false");
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.queryByText("Total Points")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/__tests__/choreSort.test.js
+++ b/frontend/src/__tests__/choreSort.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { compareChoresByNextDue } from "../utils/choreSort";
+
+describe("compareChoresByNextDue", () => {
+  it("sorts due before complete regardless of date", () => {
+    const complete = { state: "complete", next_due: "2024-01-10", name: "A" };
+    const due = { state: "due", next_due: "2024-01-15", name: "B" };
+    expect(compareChoresByNextDue(due, complete)).toBeLessThan(0);
+    expect(compareChoresByNextDue(complete, due)).toBeGreaterThan(0);
+  });
+
+  it("sorts by date ascending within same state", () => {
+    const earlier = { state: "due", next_due: "2024-01-10", name: "A" };
+    const later = { state: "due", next_due: "2024-01-15", name: "B" };
+    expect(compareChoresByNextDue(earlier, later)).toBeLessThan(0);
+    expect(compareChoresByNextDue(later, earlier)).toBeGreaterThan(0);
+  });
+
+  it("sorts by name when state and date are equal", () => {
+    const a = { state: "due", next_due: "2024-01-10", name: "Apple" };
+    const b = { state: "due", next_due: "2024-01-10", name: "Banana" };
+    expect(compareChoresByNextDue(a, b)).toBeLessThan(0);
+    expect(compareChoresByNextDue(b, a)).toBeGreaterThan(0);
+  });
+
+  it("places no-date chores last within same state group", () => {
+    const noDate = { state: "due", next_due: null, name: "A" };
+    const withDate = { state: "due", next_due: "2024-01-10", name: "B" };
+    expect(compareChoresByNextDue(noDate, withDate)).toBeGreaterThan(0);
+    expect(compareChoresByNextDue(withDate, noDate)).toBeLessThan(0);
+  });
+
+  it("places complete no-date after complete with-date, both after all due", () => {
+    const dueWithDate = { state: "due", next_due: "2024-01-20", name: "A" };
+    const completeWithDate = { state: "complete", next_due: "2024-01-10", name: "B" };
+    const completeNoDate = { state: "complete", next_due: null, name: "C" };
+
+    const sorted = [completeNoDate, completeWithDate, dueWithDate].sort(compareChoresByNextDue);
+    expect(sorted.map(c => c.name)).toEqual(["A", "B", "C"]);
+  });
+});

--- a/frontend/src/components/ChoreList.css
+++ b/frontend/src/components/ChoreList.css
@@ -4,6 +4,10 @@
   gap: 1rem;
 }
 
+.chore-state-spacer {
+  grid-column: 1 / -1;
+}
+
 @media (min-width: 1200px) {
   .chore-list {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/components/ChoreList.jsx
+++ b/frontend/src/components/ChoreList.jsx
@@ -43,27 +43,38 @@ export default function ChoreList({ onEdit, onDelete, onComplete, onSkip, onMark
     return <div className="empty">No chores yet. Add one to get started.</div>;
   }
 
+  const hasBothStates =
+    sorted.some((c) => c.state === "due") &&
+    sorted.some((c) => c.state === "complete");
+  const firstCompleteIndex = hasBothStates
+    ? sorted.findIndex((c) => c.state === "complete")
+    : -1;
+
   return (
     <div className="chore-list" role="region" aria-label="Chores list">
-      {sorted.map((chore) => {
+      {sorted.map((chore, index) => {
         const assigneeLabel = getChoreAssigneeLabel(chore);
 
         return (
-          <ChoreCard
-            key={chore.id}
-            chore={{ ...chore, age: calculateAge(chore.next_due) }}
-            choreState={chore.state}
-            status={STATE_LABELS[chore.state] || chore.state}
-            frequency={chore.schedule_summary}
-            assignee={assigneeLabel}
-            onEdit={onEdit}
-            onDelete={onDelete}
-            onComplete={onComplete}
-            onSkip={onSkip}
-            onMarkDue={onMarkDue}
-            onHistory={(c) => navigate(`/log?chore_id=${encodeURIComponent(c.id)}`)}
-            onClick={() => {}}
-          />
+          <React.Fragment key={chore.id}>
+            {index === firstCompleteIndex && (
+              <div className="chore-state-spacer" aria-hidden="true" />
+            )}
+            <ChoreCard
+              chore={{ ...chore, age: calculateAge(chore.next_due) }}
+              choreState={chore.state}
+              status={STATE_LABELS[chore.state] || chore.state}
+              frequency={chore.schedule_summary}
+              assignee={assigneeLabel}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onComplete={onComplete}
+              onSkip={onSkip}
+              onMarkDue={onMarkDue}
+              onHistory={(c) => navigate(`/log?chore_id=${encodeURIComponent(c.id)}`)}
+              onClick={() => {}}
+            />
+          </React.Fragment>
         );
       })}
     </div>

--- a/frontend/src/pages/Chores.css
+++ b/frontend/src/pages/Chores.css
@@ -354,6 +354,44 @@
   background-color: var(--accent-bg) !important;
 }
 
+.chore-stats-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chore-stats-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chore-stats-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  color: var(--text-muted);
+  border-radius: var(--radius);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.btn-icon:hover {
+  color: var(--text);
+  background: var(--surface2);
+}
+
 .chore-stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
-import { MdFilterList, MdAdd, MdSearch, MdClose } from "react-icons/md";
+import { MdFilterList, MdAdd, MdSearch, MdClose, MdExpandMore, MdExpandLess } from "react-icons/md";
 import { Select, MenuItem, Chip, Box } from "@mui/material";
 import { useAuth } from "../contexts/AuthContext";
 import { getChores, getPeople, createChore, updateChore, deleteChore, completeChore, skipChore, markDueChore, getPointsSummary } from "../api/client";
@@ -83,6 +83,10 @@ export default function Manage() {
   const [modal, setModal] = useState(null); // null | { mode: "create" } | { mode: "edit", chore }
   const [deleteTarget, setDeleteTarget] = useState(null); // chore to confirm-delete
   const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [statsExpanded, setStatsExpanded] = useState(() => {
+    const stored = localStorage.getItem("chores-stats-expanded");
+    return stored === null ? true : stored === "true";
+  });
 
   const filters = useMemo(() => getFiltersFromSearchParams(searchParams), [searchParams]);
 
@@ -273,23 +277,41 @@ export default function Manage() {
         </div>
       </div>
 
-      <div className="chore-stats-grid">
-        <div className="chore-stat-card">
-          <div className="chore-stat-label">Chores</div>
-          <div className="chore-stat-value">{summaryStats.totalChores}</div>
+      <div className="chore-stats-section">
+        <div className="chore-stats-header">
+          <span className="chore-stats-label">Stats</span>
+          <button
+            className="btn-icon"
+            aria-label="Toggle stats"
+            onClick={() => {
+              const next = !statsExpanded;
+              setStatsExpanded(next);
+              localStorage.setItem("chores-stats-expanded", String(next));
+            }}
+          >
+            {statsExpanded ? <MdExpandLess className="action-icon" /> : <MdExpandMore className="action-icon" />}
+          </button>
         </div>
-        <div className="chore-stat-card">
-          <div className="chore-stat-label">Total Points</div>
-          <div className="chore-stat-value">{summaryStats.totalPoints}</div>
-        </div>
-        <div className="chore-stat-card">
-          <div className="chore-stat-label">Completed Last 7 Days</div>
-          <div className="chore-stat-value">{summaryStats.points7d}</div>
-        </div>
-        <div className="chore-stat-card">
-          <div className="chore-stat-label">Due Next 7 Days</div>
-          <div className="chore-stat-value">{summaryStats.pointsDueNext7}</div>
-        </div>
+        {statsExpanded && (
+          <div className="chore-stats-grid">
+            <div className="chore-stat-card">
+              <div className="chore-stat-label">Chores</div>
+              <div className="chore-stat-value">{summaryStats.totalChores}</div>
+            </div>
+            <div className="chore-stat-card">
+              <div className="chore-stat-label">Total Points</div>
+              <div className="chore-stat-value">{summaryStats.totalPoints}</div>
+            </div>
+            <div className="chore-stat-card">
+              <div className="chore-stat-label">Completed Last 7 Days</div>
+              <div className="chore-stat-value">{summaryStats.points7d}</div>
+            </div>
+            <div className="chore-stat-card">
+              <div className="chore-stat-label">Due Next 7 Days</div>
+              <div className="chore-stat-value">{summaryStats.pointsDueNext7}</div>
+            </div>
+          </div>
+        )}
       </div>
 
       {isLoading ? (

--- a/frontend/src/utils/choreSort.js
+++ b/frontend/src/utils/choreSort.js
@@ -1,3 +1,9 @@
+const STATE_ORDER = { due: 0, complete: 1 };
+
+function getStateOrder(state) {
+  return STATE_ORDER[state] ?? 0;
+}
+
 function getNextDueTimestamp(nextDue) {
   if (!nextDue) return Number.POSITIVE_INFINITY;
 
@@ -6,6 +12,9 @@ function getNextDueTimestamp(nextDue) {
 }
 
 export function compareChoresByNextDue(a, b) {
+  const stateDiff = getStateOrder(a.state) - getStateOrder(b.state);
+  if (stateDiff !== 0) return stateDiff;
+
   const dueDiff = getNextDueTimestamp(a.next_due) - getNextDueTimestamp(b.next_due);
   if (dueDiff !== 0) return dueDiff;
 


### PR DESCRIPTION
## Summary

- Stats section now has a collapsible header row with label and chevron toggle; preference stored in `localStorage` (key: `chores-stats-expanded`), default expanded
- `compareChoresByNextDue` sorts `due` chores before `complete` chores, then by `next_due` date within each group
- `ChoreList` injects a full-width invisible spacer (`grid-column: 1 / -1`) between the last due and first complete chore when both states are present

## Issue

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)