### PR TITLE
feat: prompt for completer when completing unassigned chore (#214)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,58 @@
+# Chores Web
+
+A household chore tracking app where people earn points for completing chores.
+
+## Language
+
+**Chore**:
+A repeating household task with a schedule, assignment strategy, and point value.
+_Avoid_: Task, item, job
+
+**Completion**:
+The event of a person marking a Chore as done, awarding points and advancing the schedule.
+_Avoid_: Finishing, doing
+
+**Assignee**:
+The person currently responsible for completing a due Chore.
+_Avoid_: Owner, user
+
+**Credit**:
+The attribution of points to a person for a Completion. Stored in the Points Log.
+_Avoid_: Award, score
+
+**Amendment**:
+An admin correction to a Points Log entry that adjusts the credited person or point value of a past Completion.
+_Avoid_: Edit, fix, reassignment (when referring to post-completion credit change)
+
+**Completer**:
+The person who physically performed a Chore. For Chores without an Assignee (`current_assignee === null`), the Completer is specified explicitly at Completion time via a required modal. The Completer receives the Credit, not the logged-in user.
+_Avoid_: Doer, performer
+
+**Reassignment**:
+Changing the Assignee of a due (not yet completed) Chore. Does not affect the Points Log.
+_Avoid_: Transfer (when referring to a pre-completion assignee change)
+
+**Points Log**:
+Append-only record of all Credits. One entry per Completion.
+_Avoid_: Score log, history
+
+**Activity Log**:
+Unified audit trail of all chore events: completions, skips, reassignments, amendments, and config changes. Backed by ChoreLog and UserLog merged at query time.
+_Avoid_: Event log, audit log, history
+
+## Relationships
+
+- A **Chore** produces one **Points Log** entry per **Completion**
+- A **Completion** produces one **Activity Log** entry with action `completed`
+- An **Amendment** appends one **Activity Log** entry with action `amended` without modifying the original `completed` entry
+- A **Reassignment** applies only to due Chores and never touches the **Points Log**
+- A **Completer** is the Assignee when `current_assignee` is set; when `current_assignee === null`, the Completer is selected explicitly at Completion time
+
+## Example dialogue
+
+> **Dev:** "If we move credit from Alice to Bob, should we update Alice's `completed` entry in the Activity Log?"
+> **Domain expert:** "No — Alice did complete the chore. The Amendment records the credit transfer separately. The original `completed` entry is preserved."
+
+## Flagged ambiguities
+
+- "reassigned" appears in two senses: (1) changing who will do a due Chore — this is a **Reassignment** — and (2) changing who gets credit after Completion — this is an **Amendment**. These are now distinct terms with distinct `action` values in the Activity Log.

--- a/backend/app/routers/chores.py
+++ b/backend/app/routers/chores.py
@@ -335,7 +335,7 @@ async def delete_chore(chore_id: int, current_user: str = Depends(get_current_us
 @router.post("/{chore_id}/complete", response_model=ChoreOut)
 async def action_complete(chore_id: int, body: CompleteBody, current_user: str = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
     chore = await _get_or_404(chore_id, db)
-    return _enrich(await complete_chore(chore, db, completed_by=current_user))
+    return _enrich(await complete_chore(chore, db, completed_by=body.completed_by or current_user))
 
 
 @router.post("/{chore_id}/skip", response_model=ChoreOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -135,7 +135,7 @@ class ChoreOut(BaseModel):
 # ── Actions ───────────────────────────────────────────────────────────────────
 
 class CompleteBody(BaseModel):
-    pass
+    completed_by: Optional[str] = None
 
 
 class SkipReassignBody(BaseModel):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -488,6 +488,31 @@ class TestChoresAPI:
         assert r.json()["last_completed_by"] == "testuser"
 
     @pytest.mark.asyncio
+    async def test_complete_with_completed_by_uses_specified_person(self, authenticated_client):
+        r = await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
+        assert r.status_code == 201
+
+        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+
+        # Complete with explicit completed_by — should credit alice, not testuser
+        r = await authenticated_client.post(f"/chores/{chore_id}/complete", json={"completed_by": "alice"})
+        assert r.status_code == 200
+        assert r.json()["last_completed_by"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_complete_without_completed_by_falls_back_to_auth_user(self, authenticated_client):
+        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
+        chore_id = r.json()["id"]
+        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
+
+        # No completed_by — falls back to current_user (testuser)
+        r = await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
+        assert r.status_code == 200
+        assert r.json()["last_completed_by"] == "testuser"
+
+    @pytest.mark.asyncio
     async def test_open_chore_clears_assignee_after_completion(self, authenticated_client):
         r = await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
         assert r.status_code == 201

--- a/docs/api/chores.md
+++ b/docs/api/chores.md
@@ -115,14 +115,18 @@ Delete chore and all associated points history.
 ---
 
 ## POST /chores/{chore_id}/complete
-Mark chore completed, award points.
+Mark chore completed, award points. The Completer receives the Credit.
 
 **Request:**
 ```json
 {
-  "completed_by": "string|null"
+  "completed_by": "string (optional)"
 }
 ```
+
+- `completed_by`: Username of the **Completer**. Optional — omit or pass `null` to fall back to the authenticated user.
+- When `current_assignee === null` (no Assignee), the frontend enforces a required **Completer** selection before calling this endpoint.
+- The Completer receives the Credit (Points Log entry), regardless of which user made the HTTP request.
 
 **Response (200):** Updated chore
 

--- a/frontend/src/__tests__/ChoreRowActions.test.jsx
+++ b/frontend/src/__tests__/ChoreRowActions.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ChoreRowActions from "../components/ChoreRowActions";
@@ -17,7 +17,18 @@ const CHORE = {
   next_due: "2024-01-10",
 };
 
-const PEOPLE = [{ name: "Alice" }, { name: "Bob" }];
+const PEOPLE = [{ name: "Alice", username: "alice" }, { name: "Bob", username: "bob" }];
+
+const UNASSIGNED_CHORE = {
+  id: "bathroom",
+  unique_id: "bathroom",
+  name: "Bathroom",
+  state: "due",
+  disabled: false,
+  age: 0,
+  next_due: "2024-01-10",
+  current_assignee: null,
+};
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -76,6 +87,60 @@ describe("ChoreRowActions — due mode", () => {
     wrap(<ChoreRowActions chore={CHORE} person={null} people={[]} mode="due" />);
     fireEvent.click(screen.getByText("Complete"));
     await waitFor(() => expect(client.completeChore).toHaveBeenCalledWith("vacuum", null));
+  });
+
+  describe("CompleteWithActorModal — unassigned chore", () => {
+    beforeEach(() => {
+      client.completeChore.mockResolvedValue({ ...UNASSIGNED_CHORE, state: "complete" });
+    });
+
+    it("shows actor modal instead of completing directly when current_assignee is null", async () => {
+      wrap(<ChoreRowActions chore={UNASSIGNED_CHORE} person={null} people={PEOPLE} mode="due" />);
+      fireEvent.click(screen.getByText("Complete"));
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+      expect(client.completeChore).not.toHaveBeenCalled();
+    });
+
+    it("calls completeChore with selected username when modal is confirmed", async () => {
+      wrap(<ChoreRowActions chore={UNASSIGNED_CHORE} person={null} people={PEOPLE} mode="due" />);
+      fireEvent.click(screen.getByText("Complete"));
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+
+      // Select Alice in the modal
+      const dialog = screen.getByRole("dialog");
+      const select = within(dialog).getByRole("combobox");
+      fireEvent.change(select, { target: { value: "alice" } });
+      fireEvent.click(within(dialog).getByRole("button", { name: /^complete$/i }));
+
+      await waitFor(() => expect(client.completeChore).toHaveBeenCalledWith("bathroom", "alice"));
+    });
+
+    it("does not call completeChore when modal is cancelled", async () => {
+      wrap(<ChoreRowActions chore={UNASSIGNED_CHORE} person={null} people={PEOPLE} mode="due" />);
+      fireEvent.click(screen.getByText("Complete"));
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      await waitFor(() => expect(screen.queryByText(/who completed/i)).not.toBeInTheDocument());
+      expect(client.completeChore).not.toHaveBeenCalled();
+    });
+
+    it("modal shows all people by name", async () => {
+      wrap(<ChoreRowActions chore={UNASSIGNED_CHORE} person={null} people={PEOPLE} mode="due" />);
+      fireEvent.click(screen.getByText("Complete"));
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+
+      expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Bob").length).toBeGreaterThan(0);
+    });
+
+    it("does not show modal for chore with an assignee", async () => {
+      const assignedChore = { ...CHORE, current_assignee: "alice" };
+      wrap(<ChoreRowActions chore={assignedChore} person="Alice" people={PEOPLE} mode="due" />);
+      fireEvent.click(screen.getByText("Complete"));
+      await waitFor(() => expect(client.completeChore).toHaveBeenCalled());
+      expect(screen.queryByText(/who completed/i)).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/__tests__/Chores.test.jsx
+++ b/frontend/src/__tests__/Chores.test.jsx
@@ -115,7 +115,7 @@ const CHORES = [
   },
 ];
 
-const PEOPLE = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }];
+const PEOPLE = [{ id: 1, name: "Alice", username: "alice" }, { id: 2, name: "Bob", username: "bob" }];
 
 function LocationDisplay() {
   const location = useLocation();
@@ -697,6 +697,76 @@ describe("Manage page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
+    });
+  });
+
+  describe("CompleteWithActorModal — unassigned chore", () => {
+    it("shows actor modal when Complete clicked for chore with current_assignee null", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Bathroom")).toBeInTheDocument());
+
+      // Expand Bathroom card (current_assignee: null)
+      const bathroomCard = screen.getByText("Bathroom").closest("article");
+      fireEvent.click(bathroomCard);
+
+      await waitFor(() => expect(screen.getByText("Complete")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("Complete"));
+
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+      expect(client.completeChore).not.toHaveBeenCalled();
+    });
+
+    it("calls completeChore with username after modal confirm", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Bathroom")).toBeInTheDocument());
+
+      const bathroomCard = screen.getByText("Bathroom").closest("article");
+      fireEvent.click(bathroomCard);
+
+      await waitFor(() => expect(screen.getByText("Complete")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("Complete"));
+
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+
+      // PEOPLE = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
+      // Need username field — but test fixture doesn't have it yet;
+      // we'll add it when implementing. For now test structure is correct.
+      const select = screen.getByRole("combobox", { name: /select a person/i });
+      fireEvent.change(select, { target: { value: "alice" } });
+      fireEvent.click(screen.getByRole("button", { name: /^complete$/i }));
+
+      await waitFor(() => expect(client.completeChore).toHaveBeenCalledWith("bathroom", "alice"));
+    });
+
+    it("closes modal without calling completeChore when cancelled", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Bathroom")).toBeInTheDocument());
+
+      const bathroomCard = screen.getByText("Bathroom").closest("article");
+      fireEvent.click(bathroomCard);
+
+      await waitFor(() => expect(screen.getByText("Complete")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("Complete"));
+
+      await waitFor(() => expect(screen.getByText(/who completed/i)).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+      await waitFor(() => expect(screen.queryByText(/who completed/i)).not.toBeInTheDocument());
+      expect(client.completeChore).not.toHaveBeenCalled();
+    });
+
+    it("does not show modal for chore with an assignee (Vacuum, assigned to Alice)", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+
+      const vacuumCard = screen.getByText("Vacuum").closest("article");
+      fireEvent.click(vacuumCard);
+
+      await waitFor(() => expect(screen.getByText("Complete")).toBeInTheDocument());
+      fireEvent.click(screen.getByText("Complete"));
+
+      await waitFor(() => expect(client.completeChore).toHaveBeenCalled());
+      expect(screen.queryByText(/who completed/i)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -51,8 +51,8 @@ export const createChore = (data) => request("POST", "/chores", data);
 export const updateChore = (id, data) => request("PUT", `/chores/${id}`, data);
 export const deleteChore = (id) => request("DELETE", `/chores/${id}`);
 
-export const completeChore = (id) =>
-  request("POST", `/chores/${id}/complete`, {});
+export const completeChore = (id, completedBy) =>
+  request("POST", `/chores/${id}/complete`, completedBy ? { completed_by: completedBy } : {});
 export const skipChore = (id) => request("POST", `/chores/${id}/skip`);
 export const skipReassignChore = (id, assignee) =>
   request("POST", `/chores/${id}/skip-reassign`, { assignee: assignee ?? null });

--- a/frontend/src/components/ChoreRowActions.jsx
+++ b/frontend/src/components/ChoreRowActions.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { completeChore, skipChore, reassignChore, markDueChore } from "../api/client";
 import { getPersonColor } from "../utils/personColors";
+import CompleteWithActorModal from "./CompleteWithActorModal";
 import Toast from "./Toast";
 import "./ChoreRowActions.css";
 
@@ -23,6 +24,7 @@ export default function ChoreRowActions({ chore, person, people, mode }) {
   const [reassignTarget, setReassignTarget] = useState("");
   const [justDone, setJustDone] = useState(false);
   const [toast, setToast] = useState(null);
+  const [actorModalOpen, setActorModalOpen] = useState(false);
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ["chores"] });
@@ -30,13 +32,26 @@ export default function ChoreRowActions({ chore, person, people, mode }) {
   };
 
   const complete = useMutation({
-    mutationFn: () => completeChore(chore.id, person ?? null),
+    mutationFn: (completedBy) => completeChore(chore.id, completedBy ?? person ?? null),
     onSuccess: () => {
       setJustDone(true);
       if (chore.points) setToast(`+${chore.points} pts!`);
       invalidate();
     },
   });
+
+  const handleCompleteClick = () => {
+    if (chore.current_assignee === null) {
+      setActorModalOpen(true);
+    } else {
+      complete.mutate(undefined);
+    }
+  };
+
+  const handleActorConfirm = (username) => {
+    setActorModalOpen(false);
+    complete.mutate(username);
+  };
   const skip = useMutation({
     mutationFn: () => skipChore(chore.id),
     onSuccess: invalidate,
@@ -56,6 +71,14 @@ export default function ChoreRowActions({ chore, person, people, mode }) {
   return (
     <>
       {toast && <Toast message={toast} onDone={() => setToast(null)} />}
+      {actorModalOpen && (
+        <CompleteWithActorModal
+          chore={chore}
+          people={people}
+          onConfirm={handleActorConfirm}
+          onCancel={() => setActorModalOpen(false)}
+        />
+      )}
       <div className={`chore-row ${justDone ? "done" : ""}`} onClick={(e) => e.stopPropagation()}>
         <div className={`chore-row-icon ${justDone ? "done" : ""}`}>
           {justDone
@@ -91,7 +114,7 @@ export default function ChoreRowActions({ chore, person, people, mode }) {
 
           {mode === "due" && (
             <>
-              <button className="btn-primary btn-xs" disabled={busy || justDone} onClick={() => complete.mutate()}>
+              <button className="btn-primary btn-xs" disabled={busy || justDone} onClick={handleCompleteClick}>
                 Complete
               </button>
               <button className="btn-secondary btn-xs" disabled={busy} onClick={() => skip.mutate()}>

--- a/frontend/src/components/CompleteWithActorModal.jsx
+++ b/frontend/src/components/CompleteWithActorModal.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import Modal from "./Modal";
+
+export default function CompleteWithActorModal({ chore, people, onConfirm, onCancel }) {
+  const [selected, setSelected] = useState("");
+
+  return (
+    <Modal title={`Who completed ${chore.name}?`} onClose={onCancel}>
+      <div className="complete-actor-modal">
+        <div className="form-group">
+          <label htmlFor="actor-select">Select a person</label>
+          <select
+            id="actor-select"
+            aria-label="Select a person"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            <option value="">Select a person…</option>
+            {people.map((p) => (
+              <option key={p.username} value={p.username}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="confirm-actions">
+          <button className="btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary"
+            disabled={!selected}
+            onClick={() => onConfirm(selected)}
+          >
+            Complete
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -8,6 +8,7 @@ import { getChores, getPeople, createChore, updateChore, deleteChore, completeCh
 import ChoreForm from "../components/ChoreForm";
 import ChoreList from "../components/ChoreList";
 import Modal from "../components/Modal";
+import CompleteWithActorModal from "../components/CompleteWithActorModal";
 import {
   choreMatchesAssigneeFilter,
   UNASSIGNED_FILTER_VALUE,
@@ -82,6 +83,7 @@ export default function Manage() {
 
   const [modal, setModal] = useState(null); // null | { mode: "create" } | { mode: "edit", chore }
   const [deleteTarget, setDeleteTarget] = useState(null); // chore to confirm-delete
+  const [completeTarget, setCompleteTarget] = useState(null); // chore awaiting actor selection
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [statsExpanded, setStatsExpanded] = useState(() => {
     const stored = localStorage.getItem("chores-stats-expanded");
@@ -123,7 +125,7 @@ export default function Manage() {
   });
 
   const completeMut = useMutation({
-    mutationFn: (id) => completeChore(id),
+    mutationFn: ({ id, completedBy }) => completeChore(id, completedBy),
     onSuccess: () => { invalidate(); setCompleteTarget(null); },
   });
 
@@ -464,7 +466,11 @@ export default function Manage() {
             onEdit={(chore) => setModal({ mode: "edit", chore })}
             onDelete={(chore) => setDeleteTarget(chore)}
             onComplete={(chore) => {
-              completeMut.mutate(chore.id);
+              if (chore.current_assignee === null) {
+                setCompleteTarget(chore);
+              } else {
+                completeMut.mutate({ id: chore.id });
+              }
             }}
             onSkip={(chore) => skipMut.mutate(chore.id)}
             onMarkDue={(chore) => markDueMut.mutate(chore.id)}
@@ -493,6 +499,16 @@ export default function Manage() {
             }}
           />
         </Modal>
+      )}
+
+      {/* Complete actor selection modal */}
+      {completeTarget && (
+        <CompleteWithActorModal
+          chore={completeTarget}
+          people={people}
+          onConfirm={(username) => completeMut.mutate({ id: completeTarget.id, completedBy: username })}
+          onCancel={() => setCompleteTarget(null)}
+        />
       )}
 
       {/* Delete confirmation modal */}


### PR DESCRIPTION
## Summary

- Add `completed_by: Optional[str]` to `CompleteBody`; `action_complete` uses `body.completed_by or current_user`
- New `CompleteWithActorModal` shared component — required person selector, displays name, submits username, cancel aborts completion
- Modal triggers when `chore.current_assignee === null` in both `ChoreRowActions` and `Chores.jsx` (card view)
- `completeChore(id, completedBy?)` now passes `completed_by` in request body when provided
- Pre-implementation docs committed: **Completer** term added to `CONTEXT.md`; `docs/api/chores.md` updated to document `completed_by` semantics
- Fixes pre-existing bug in `Chores.jsx` where `completeTarget` state was referenced but never declared

## Issue

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)