### PR TITLE
fix: bypass throttle and cache on manual update check (#261)

### DIFF
--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -162,7 +162,7 @@ async def trigger_update_check(
     db: AsyncSession = Depends(get_db),
 ):
     """Manually trigger an update check (admin only)."""
-    await check_for_updates(db)
+    await check_for_updates(db, force=True)
     return await get_update_status(db)
 
 

--- a/backend/app/services/update_check_service.py
+++ b/backend/app/services/update_check_service.py
@@ -21,13 +21,14 @@ _version_cache = {
 }
 
 
-async def _get_github_latest_version(timeout: int = 5) -> Optional[str]:
+async def _get_github_latest_version(timeout: int = 5, force: bool = False) -> Optional[str]:
     """Fetch the latest release version from GitHub API with caching."""
     now = datetime.utcnow()
 
-    # Check if cache is still valid
+    # Check if cache is still valid (bypassed when force=True)
     if (
-        _version_cache["latest_version"] is not None
+        not force
+        and _version_cache["latest_version"] is not None
         and _version_cache["cached_at"] is not None
         and (now - _version_cache["cached_at"]).total_seconds() < _version_cache["cache_ttl_seconds"]
     ):
@@ -55,7 +56,7 @@ async def _get_github_latest_version(timeout: int = 5) -> Optional[str]:
         return None
 
 
-async def check_for_updates(db: AsyncSession) -> Optional[str]:
+async def check_for_updates(db: AsyncSession, force: bool = False) -> Optional[str]:
     """Check for updates and return latest version if available."""
     result = await db.execute(select(UpdateCheck).limit(1))
     update_check = result.scalar_one_or_none()
@@ -73,8 +74,8 @@ async def check_for_updates(db: AsyncSession) -> Optional[str]:
         update_check.current_version = APP_VERSION
         await db.commit()
 
-    # Check if enough time has passed since last check
-    if update_check.last_checked_at:
+    # Check if enough time has passed since last check (bypassed when force=True)
+    if not force and update_check.last_checked_at:
         time_since_check = datetime.utcnow() - update_check.last_checked_at.replace(tzinfo=None)
         if time_since_check.total_seconds() < update_check.check_interval_hours * 3600:
             logger.debug("Update check skipped (interval not yet reached)")
@@ -85,8 +86,8 @@ async def check_for_updates(db: AsyncSession) -> Optional[str]:
         logger.debug("Update checking is disabled")
         return update_check.latest_version
 
-    # Fetch latest version from GitHub
-    latest_version = await _get_github_latest_version()
+    # Fetch latest version from GitHub (force bypasses in-memory version cache)
+    latest_version = await _get_github_latest_version(force=force)
 
     # Update the record
     update_check.latest_version = latest_version

--- a/backend/tests/test_update_check_routes.py
+++ b/backend/tests/test_update_check_routes.py
@@ -1,6 +1,7 @@
 """Tests for update check API endpoints."""
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.main import app
@@ -77,3 +78,31 @@ async def test_configure_update_check_with_query_params(db: AsyncSession):
     # This would be tested in integration tests
     # Verify the endpoint accepts query parameters
     pass
+
+
+@pytest.mark.asyncio
+async def test_trigger_update_check_calls_with_force_true(authenticated_client):
+    """Behavior 4: trigger_update_check router endpoint calls check_for_updates(db, force=True)."""
+    with patch(
+        "app.routers.config.check_for_updates",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as mock_check, patch(
+        "app.routers.config.get_update_status",
+        new_callable=AsyncMock,
+        return_value={
+            "current_version": APP_VERSION,
+            "latest_version": APP_VERSION,
+            "last_checked_at": None,
+            "check_enabled": True,
+            "check_interval_hours": 24,
+            "update_available": False,
+        },
+    ):
+        response = await authenticated_client.post("/config/updates/check")
+        assert response.status_code == 200
+
+        # Must have been called with force=True
+        mock_check.assert_called_once()
+        _, kwargs = mock_check.call_args
+        assert kwargs.get("force") is True

--- a/backend/tests/test_update_check_service.py
+++ b/backend/tests/test_update_check_service.py
@@ -1,6 +1,7 @@
 """Tests for update check service."""
 import pytest
 from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +10,7 @@ from app.services.update_check_service import (
     check_for_updates,
     get_update_status,
     configure_update_check,
+    _version_cache,
 )
 
 
@@ -154,3 +156,75 @@ async def test_version_comparison_ignores_same_version(db: AsyncSession):
 
     # Verify no update is available
     assert status["update_available"] is False
+
+
+# --- Behaviors from issue #261 ---
+
+@pytest.mark.asyncio
+async def test_check_for_updates_accepts_force_param(db: AsyncSession):
+    """Behavior 1: check_for_updates accepts force: bool = False param."""
+    with patch(
+        "app.services.update_check_service._get_github_latest_version",
+        new_callable=AsyncMock,
+        return_value="1.0.0",
+    ):
+        # Should not raise TypeError
+        await check_for_updates(db, force=False)
+        await check_for_updates(db, force=True)
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_force_bypasses_db_interval_guard(db: AsyncSession):
+    """Behavior 2: force=True skips DB interval guard."""
+    # Record with last check 1 hour ago — within 24h interval, so normally skipped
+    initial_time = datetime.utcnow() - timedelta(hours=1)
+    update_check = UpdateCheck(
+        current_version="1.0.0",
+        check_enabled=True,
+        check_interval_hours=24,
+        last_checked_at=initial_time,
+        latest_version="1.0.0",
+    )
+    db.add(update_check)
+    await db.commit()
+
+    with patch(
+        "app.services.update_check_service._get_github_latest_version",
+        new_callable=AsyncMock,
+        return_value="2.0.0",
+    ) as mock_fetch:
+        await check_for_updates(db, force=True)
+        mock_fetch.assert_called_once()  # Real fetch happened despite recent check
+
+    # last_checked_at must have been updated
+    result = await db.execute(select(UpdateCheck).limit(1))
+    record = result.scalar_one_or_none()
+    time_since_initial = (record.last_checked_at.replace(tzinfo=None) - initial_time).total_seconds()
+    assert time_since_initial > 0  # Updated beyond initial_time
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_force_bypasses_version_cache(db: AsyncSession):
+    """Behavior 3: force=True skips in-memory _version_cache TTL check."""
+    # Pre-populate cache as if a fresh fetch just happened
+    _version_cache["latest_version"] = "1.0.0"
+    _version_cache["cached_at"] = datetime.utcnow()  # Cache is fresh
+
+    update_check = UpdateCheck(
+        current_version="1.0.0",
+        check_enabled=True,
+        check_interval_hours=1,
+        last_checked_at=datetime.utcnow() - timedelta(hours=25),  # Old enough to pass interval
+        latest_version="1.0.0",
+    )
+    db.add(update_check)
+    await db.commit()
+
+    with patch(
+        "app.services.update_check_service._get_github_latest_version",
+        new_callable=AsyncMock,
+        return_value="2.0.0",
+    ) as mock_fetch:
+        await check_for_updates(db, force=True)
+        # Must have called _get_github_latest_version even though cache was fresh
+        mock_fetch.assert_called_once()

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -30,16 +30,18 @@ Get current update check status. Admin only.
 **Response (200):**
 ```json
 {
-  "last_check": "ISO8601|null",
-  "available_version": "string|null",
-  "is_checking": boolean,
-  "enabled": boolean,
-  "interval_hours": integer
+  "last_checked_at": "ISO8601|null",
+  "latest_version": "string|null",
+  "update_available": boolean,
+  "check_enabled": boolean,
+  "check_interval_hours": integer
 }
 ```
 
 ## POST /config/updates/check
 Manually trigger an update check. Admin only.
+
+Always performs a real check against GitHub — bypasses both the interval throttle and in-memory version cache regardless of when the last check ran.
 
 **Response (200):** Updated status (see above)
 


### PR DESCRIPTION
## Summary

- Add `force: bool = False` param to `check_for_updates` and `_get_github_latest_version` in `update_check_service.py`
- When `force=True`, skip DB interval guard — manual check always fetches regardless of `check_interval_hours`
- When `force=True`, skip in-memory `_version_cache` TTL — forces real GitHub API call
- `trigger_update_check` router endpoint calls `check_for_updates(db, force=True)`; background scheduler path unchanged
- Fix stale field names in `docs/api/config.md` (`last_checked_at`, `latest_version`, `update_available`, `check_enabled`, `check_interval_hours`)
- Add behavior note to `POST /config/updates/check` docs: always bypasses interval throttle and version cache

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)