### PR TITLE
feat: mobile chores page improvements (#267)

### DIFF
--- a/frontend/src/__tests__/Chores.test.jsx
+++ b/frontend/src/__tests__/Chores.test.jsx
@@ -140,6 +140,7 @@ describe("Manage page", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     localStorage.clear();
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
     client.getChores.mockResolvedValue(CHORES);
     client.getPeople.mockResolvedValue(PEOPLE);
     client.getPointsSummary.mockResolvedValue([]);
@@ -668,6 +669,28 @@ describe("Manage page", () => {
       await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
       expect(screen.queryByText("Total Points")).not.toBeInTheDocument();
     });
+
+    it("defaults collapsed on mobile cold-start (no localStorage, width <= 768)", async () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.queryByText("Total Points")).not.toBeInTheDocument();
+    });
+
+    it("defaults expanded on desktop cold-start (no localStorage, width > 768)", async () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.getByText("Total Points")).toBeInTheDocument();
+    });
+
+    it("respects localStorage expanded=true on mobile (overrides mobile default)", async () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+      localStorage.setItem("chores-stats-expanded", "true");
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      expect(screen.getByText("Total Points")).toBeInTheDocument();
+    });
   });
 
   it("applies search and filter together without clearing either", async () => {
@@ -697,6 +720,38 @@ describe("Manage page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Vacuum")).toBeInTheDocument();
+    });
+  });
+
+  describe("section ordering", () => {
+    it("filter panel appears before stats section in DOM", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+      await waitFor(() => expect(document.querySelector(".chore-filters")).toBeInTheDocument());
+
+      const filters = document.querySelector(".chore-filters");
+      const stats = document.querySelector(".chore-stats-section");
+      // DOCUMENT_POSITION_FOLLOWING = 4: stats follows filters (filters comes first)
+      expect(filters.compareDocumentPosition(stats) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
+
+  describe("mobile header layout", () => {
+    it("search-box is direct child of page-header (not wrapped in header-controls)", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      const pageHeader = document.querySelector('.page-header');
+      const searchBox = document.querySelector('.search-box');
+      expect(searchBox.parentElement).toBe(pageHeader);
+    });
+
+    it("header-actions is direct child of page-header (not wrapped in header-controls)", async () => {
+      wrap(<Chores />);
+      await waitFor(() => expect(screen.getByText("Vacuum")).toBeInTheDocument());
+      const pageHeader = document.querySelector('.page-header');
+      const headerActions = document.querySelector('.header-actions');
+      expect(headerActions.parentElement).toBe(pageHeader);
     });
   });
 

--- a/frontend/src/pages/Chores.css
+++ b/frontend/src/pages/Chores.css
@@ -11,17 +11,12 @@
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .page-header h2 {
   margin: 0;
-}
-
-.header-controls {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-shrink: 0;
 }
 
 .search-box {
@@ -34,6 +29,10 @@
   border-radius: var(--radius);
   flex: 1;
   min-width: 200px;
+  max-width: 50%;
+  overflow: hidden;
+  height: 2.5rem;
+  box-sizing: border-box;
 }
 
 .search-icon {
@@ -44,12 +43,14 @@
 
 .search-input {
   flex: 1;
+  min-width: 0;
   border: none;
   background: transparent;
   color: var(--text);
   font-size: 0.9rem;
   padding: 0.25rem 0;
   outline: none;
+  height: 100%;
 }
 
 .search-input::placeholder {
@@ -102,14 +103,13 @@
 }
 
 @media (max-width: 768px) {
-  .header-controls {
-    flex-direction: column;
-    width: 100%;
-    gap: 0.75rem;
-  }
-
   .search-box {
     min-width: auto;
+    max-width: 50%;
+  }
+
+  .header-actions {
+    flex: 0 0 100%;
     width: 100%;
   }
 

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -87,7 +87,8 @@ export default function Manage() {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [statsExpanded, setStatsExpanded] = useState(() => {
     const stored = localStorage.getItem("chores-stats-expanded");
-    return stored === null ? true : stored === "true";
+    if (stored !== null) return stored === "true";
+    return window.innerWidth > 768;
   });
 
   const filters = useMemo(() => getFiltersFromSearchParams(searchParams), [searchParams]);
@@ -245,39 +246,173 @@ export default function Manage() {
     <div className="manage-page">
       <div className="page-header">
         <h2>All Chores</h2>
-        <div className="header-controls">
-          <div className="search-box">
-            <MdSearch className="search-icon" />
-            <input
-              type="text"
-              placeholder="Search..."
-              value={filters.search || ""}
-              onChange={(e) => handleSearchChange(e.target.value)}
-              className="search-input"
-            />
-            {filters.search && (
-              <button
-                className="search-clear"
-                onClick={() => handleSearchChange("")}
-                title="Clear search"
-                aria-label="Clear search"
-              >
-                <MdClose className="search-clear-icon" />
-              </button>
-            )}
-          </div>
-          <div className="header-actions">
-            <button className="btn-secondary" onClick={() => setFiltersExpanded(!filtersExpanded)} title={filtersExpanded ? "Hide filters" : "Show filters"}>
-              <MdFilterList className="action-icon" />
-              <span className="action-text">{filtersExpanded ? "Hide filters" : "Show filters"}</span>
+        <div className="search-box">
+          <MdSearch className="search-icon" />
+          <input
+            type="text"
+            placeholder="Search..."
+            value={filters.search || ""}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="search-input"
+          />
+          {filters.search && (
+            <button
+              className="search-clear"
+              onClick={() => handleSearchChange("")}
+              title="Clear search"
+              aria-label="Clear search"
+            >
+              <MdClose className="search-clear-icon" />
             </button>
-            <button className="btn-primary" onClick={() => setModal({ mode: "create" })} title="Add Chore">
-              <MdAdd className="action-icon" />
-              <span className="action-text">Add Chore</span>
-            </button>
-          </div>
+          )}
+        </div>
+        <div className="header-actions">
+          <button className="btn-secondary" onClick={() => setFiltersExpanded(!filtersExpanded)} title={filtersExpanded ? "Hide filters" : "Show filters"}>
+            <MdFilterList className="action-icon" />
+            <span className="action-text">{filtersExpanded ? "Hide filters" : "Show filters"}</span>
+          </button>
+          <button className="btn-primary" onClick={() => setModal({ mode: "create" })} title="Add Chore">
+            <MdAdd className="action-icon" />
+            <span className="action-text">Add Chore</span>
+          </button>
         </div>
       </div>
+
+      {Object.keys(filters).length > 0 && (
+        <div className="filter-bar">
+          {user && filters.assignees?.length === 2 && Object.keys(filters).length === 1 && (
+            <span className="filter-hint">Showing chores assigned to you and unassigned</span>
+          )}
+          <button className="btn-secondary" onClick={handleClearFilters}>
+            Clear filters
+          </button>
+        </div>
+      )}
+
+      {filtersExpanded && (
+        <div className="chore-filters">
+          <div className="filter-group">
+            <label htmlFor="filter-schedule">Schedule type</label>
+            <Select
+              id="filter-schedule"
+              value={filters.schedule_type || ""}
+              onChange={(e) => handleFilterChange("schedule_type", e.target.value)}
+              {...SELECT_CONFIG}
+            >
+              <MenuItem value="">All types</MenuItem>
+              {scheduleTypes.map((type) => (
+                <MenuItem key={type} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="filter-assignment">Assignment type</label>
+            <Select
+              id="filter-assignment"
+              value={filters.assignment_type || ""}
+              onChange={(e) => handleFilterChange("assignment_type", e.target.value)}
+              {...SELECT_CONFIG}
+            >
+              <MenuItem value="">All types</MenuItem>
+              {assignmentTypes.map((type) => (
+                <MenuItem key={type} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="filter-assignee">Assignee</label>
+            <Select
+              id="filter-assignee"
+              multiple
+              value={filters.assignees || []}
+              onChange={(e) => handleFilterChange("assignees", e.target.value)}
+              {...SELECT_CONFIG}
+              sx={{
+                ...SELECT_CONFIG.sx,
+                "& .MuiChip-root": {
+                  backgroundColor: "var(--accent-bg)",
+                  color: "var(--text)",
+                  borderColor: "var(--accent)",
+                },
+              }}
+              renderValue={(selected) => (
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                  {selected.map((value) => (
+                    <Chip
+                      key={value}
+                      label={value === UNASSIGNED_FILTER_VALUE ? UNASSIGNED_LABEL : value}
+                    />
+                  ))}
+                </Box>
+              )}
+            >
+              {assignees.map((assignee) => (
+                <MenuItem key={assignee} value={assignee}>
+                  {assignee}
+                </MenuItem>
+              ))}
+              <MenuItem value={UNASSIGNED_FILTER_VALUE}>{UNASSIGNED_LABEL}</MenuItem>
+            </Select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="filter-state">State</label>
+            <Select
+              id="filter-state"
+              value={filters.state || ""}
+              onChange={(e) => handleFilterChange("state", e.target.value)}
+              {...SELECT_CONFIG}
+            >
+              <MenuItem value="">All states</MenuItem>
+              {states.map((state) => (
+                <MenuItem key={state} value={state}>
+                  {state}
+                </MenuItem>
+              ))}
+            </Select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="filter-days">Due within</label>
+            <Select
+              id="filter-days"
+              value={filters.daysFromNow !== undefined ? String(filters.daysFromNow) : ""}
+              onChange={(e) => {
+                handleFilterChange("daysFromNow", e.target.value ? parseInt(e.target.value, 10) : undefined);
+              }}
+              {...SELECT_CONFIG}
+            >
+              <MenuItem value="">All chores</MenuItem>
+              <MenuItem value="0">Today</MenuItem>
+              <MenuItem value="3">Next 3 days</MenuItem>
+              <MenuItem value="7">Next 7 days</MenuItem>
+              <MenuItem value="30">Next 30 days</MenuItem>
+            </Select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="filter-disabled">Status</label>
+            <Select
+              id="filter-disabled"
+              value={filters.disabled === undefined ? "" : String(filters.disabled)}
+              onChange={(e) => {
+                handleFilterChange("disabled", e.target.value || undefined);
+              }}
+              {...SELECT_CONFIG}
+            >
+              <MenuItem value="">All chores</MenuItem>
+              <MenuItem value="false">Enabled only</MenuItem>
+              <MenuItem value="true">Disabled only</MenuItem>
+            </Select>
+          </div>
+        </div>
+      )}
 
       <div className="chore-stats-section">
         <div className="chore-stats-header">
@@ -320,142 +455,6 @@ export default function Manage() {
         <div className="loading">Loading…</div>
       ) : (
         <>
-          {Object.keys(filters).length > 0 && (
-            <div className="filter-bar">
-              {user && filters.assignees?.length === 2 && Object.keys(filters).length === 1 && (
-                <span className="filter-hint">Showing chores assigned to you and unassigned</span>
-              )}
-              <button className="btn-secondary" onClick={handleClearFilters}>
-                Clear filters
-              </button>
-            </div>
-          )}
-
-          {filtersExpanded && (
-            <div className="chore-filters">
-              <div className="filter-group">
-                <label htmlFor="filter-schedule">Schedule type</label>
-                <Select
-                  id="filter-schedule"
-                  value={filters.schedule_type || ""}
-                  onChange={(e) => handleFilterChange("schedule_type", e.target.value)}
-                  {...SELECT_CONFIG}
-                >
-                  <MenuItem value="">All types</MenuItem>
-                  {scheduleTypes.map((type) => (
-                    <MenuItem key={type} value={type}>
-                      {type}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </div>
-
-              <div className="filter-group">
-                <label htmlFor="filter-assignment">Assignment type</label>
-                <Select
-                  id="filter-assignment"
-                  value={filters.assignment_type || ""}
-                  onChange={(e) => handleFilterChange("assignment_type", e.target.value)}
-                  {...SELECT_CONFIG}
-                >
-                  <MenuItem value="">All types</MenuItem>
-                  {assignmentTypes.map((type) => (
-                    <MenuItem key={type} value={type}>
-                      {type}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </div>
-
-              <div className="filter-group">
-                <label htmlFor="filter-assignee">Assignee</label>
-                <Select
-                  id="filter-assignee"
-                  multiple
-                  value={filters.assignees || []}
-                  onChange={(e) => handleFilterChange("assignees", e.target.value)}
-                  {...SELECT_CONFIG}
-                  sx={{
-                    ...SELECT_CONFIG.sx,
-                    "& .MuiChip-root": {
-                      backgroundColor: "var(--accent-bg)",
-                      color: "var(--text)",
-                      borderColor: "var(--accent)",
-                    },
-                  }}
-                  renderValue={(selected) => (
-                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                      {selected.map((value) => (
-                        <Chip
-                          key={value}
-                          label={value === UNASSIGNED_FILTER_VALUE ? UNASSIGNED_LABEL : value}
-                        />
-                      ))}
-                    </Box>
-                  )}
-                >
-                  {assignees.map((assignee) => (
-                    <MenuItem key={assignee} value={assignee}>
-                      {assignee}
-                    </MenuItem>
-                  ))}
-                  <MenuItem value={UNASSIGNED_FILTER_VALUE}>{UNASSIGNED_LABEL}</MenuItem>
-                </Select>
-              </div>
-
-              <div className="filter-group">
-                <label htmlFor="filter-state">State</label>
-                <Select
-                  id="filter-state"
-                  value={filters.state || ""}
-                  onChange={(e) => handleFilterChange("state", e.target.value)}
-                  {...SELECT_CONFIG}
-                >
-                  <MenuItem value="">All states</MenuItem>
-                  {states.map((state) => (
-                    <MenuItem key={state} value={state}>
-                      {state}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </div>
-
-              <div className="filter-group">
-                <label htmlFor="filter-days">Due within</label>
-                <Select
-                  id="filter-days"
-                  value={filters.daysFromNow !== undefined ? String(filters.daysFromNow) : ""}
-                  onChange={(e) => {
-                    handleFilterChange("daysFromNow", e.target.value ? parseInt(e.target.value, 10) : undefined);
-                  }}
-                  {...SELECT_CONFIG}
-                >
-                  <MenuItem value="">All chores</MenuItem>
-                  <MenuItem value="0">Today</MenuItem>
-                  <MenuItem value="3">Next 3 days</MenuItem>
-                  <MenuItem value="7">Next 7 days</MenuItem>
-                  <MenuItem value="30">Next 30 days</MenuItem>
-                </Select>
-              </div>
-
-              <div className="filter-group">
-                <label htmlFor="filter-disabled">Status</label>
-                <Select
-                  id="filter-disabled"
-                  value={filters.disabled === undefined ? "" : String(filters.disabled)}
-                  onChange={(e) => {
-                    handleFilterChange("disabled", e.target.value || undefined);
-                  }}
-                  {...SELECT_CONFIG}
-                >
-                  <MenuItem value="">All chores</MenuItem>
-                  <MenuItem value="false">Enabled only</MenuItem>
-                  <MenuItem value="true">Disabled only</MenuItem>
-                </Select>
-              </div>
-            </div>
-          )}
-
           <div className="chore-count">
             Showing {sorted.length} of {chores.length} chore{chores.length !== 1 ? "s" : ""}
           </div>


### PR DESCRIPTION
## Summary
- Stats section defaults collapsed on mobile cold-start (`window.innerWidth <= 768`, no localStorage) — expanded on desktop; localStorage preference always takes priority
- Removed `header-controls` wrapper: `search-box` and `header-actions` are now direct flex children of `page-header` for correct mobile wrapping
- Mobile layout: search box stays on row 1 (right-aligned, max 50% width); filter/add buttons wrap to full-width row 2
- Search box capped at max 50% width on all viewports
- Filter panel and active filter bar moved above stats section
- Fixed search box height and `overflow: hidden` to prevent height jump and X-button escape when text is entered; `min-width: 0` on input prevents flex overflow

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)