### PR TITLE
feat: add Prometheus metrics endpoint (#202)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,10 +5,11 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette_prometheus import PrometheusMiddleware
 
 from .database import engine
 from .models import Base
-from .routers import auth, chores, people, points, log, config, theme, export, data_import, status, admin_db
+from .routers import auth, chores, people, points, log, config, theme, export, data_import, status, admin_db, metrics
 from .services.scheduler import start_scheduler, stop_scheduler
 from .services.chore_service import transition_overdue_chores, normalize_points_log_persons
 from .database import AsyncSessionLocal
@@ -52,6 +53,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(PrometheusMiddleware)
 
 
 @app.exception_handler(Exception)
@@ -75,6 +77,8 @@ app.include_router(export.router)
 app.include_router(data_import.router)
 app.include_router(status.router)
 app.include_router(admin_db.router)
+# Metrics router registered without auth dependency — public endpoint
+app.include_router(metrics.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -1,0 +1,149 @@
+"""Prometheus metrics endpoint.
+
+Exposes application metrics at GET /metrics in Prometheus text format.
+Public endpoint — no authentication required.
+Process metrics (CPU, memory, file descriptors) and HTTP request metrics
+are provided automatically by prometheus_client and starlette_prometheus.
+"""
+from datetime import date, timedelta, timezone, datetime
+
+import prometheus_client
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..models import Chore, Person, PointsLog, Settings
+
+router = APIRouter(tags=["metrics"])
+
+# ---------------------------------------------------------------------------
+# Gauge definitions — all defined at module level so they survive across
+# requests and accumulate values correctly.
+# ---------------------------------------------------------------------------
+
+_chores_total = prometheus_client.Gauge(
+    "chores_total",
+    "Total chores grouped by state and disabled flag",
+    ["state", "disabled"],
+)
+
+_chores_due_now_total = prometheus_client.Gauge(
+    "chores_due_now_total",
+    "Chores where state='due'",
+)
+
+_chores_due_soon_total = prometheus_client.Gauge(
+    "chores_due_soon_total",
+    "Chores where next_due <= today + due_soon_days",
+)
+
+_chores_due_now_by_person = prometheus_client.Gauge(
+    "chores_due_now_by_person",
+    "Due chores grouped by current_assignee",
+    ["person"],
+)
+
+_people_total = prometheus_client.Gauge(
+    "people_total",
+    "Total registered user count",
+)
+
+_points_awarded_total = prometheus_client.Gauge(
+    "points_awarded_total",
+    "Sum of all PointsLog point entries",
+)
+
+_chore_completions_by_person = prometheus_client.Gauge(
+    "chore_completions_by_person",
+    "Chore completions per person for 7d and 30d windows",
+    ["person", "window"],
+)
+
+
+async def _get_due_soon_days(db: AsyncSession) -> int:
+    """Read due_soon_days from Settings; default 3."""
+    result = await db.execute(
+        select(Settings).where(Settings.key == "due_soon_days")
+    )
+    row = result.scalar_one_or_none()
+    return int(row.value) if row else 3
+
+
+async def _collect_metrics(db: AsyncSession) -> None:
+    """Query the database and update all application gauges."""
+    today = date.today()
+    now = datetime.now(timezone.utc)
+
+    # chores_total — group by (state, disabled)
+    chore_counts = await db.execute(
+        select(Chore.state, Chore.disabled, func.count()).group_by(Chore.state, Chore.disabled)
+    )
+    # Clear current label combinations before repopulating
+    _chores_total.clear()
+    for state, disabled, count in chore_counts.all():
+        _chores_total.labels(state=state, disabled=str(disabled).lower()).set(count)
+
+    # chores_due_now_total
+    due_now = await db.execute(
+        select(func.count()).select_from(Chore).where(Chore.state == "due")
+    )
+    _chores_due_now_total.set(due_now.scalar_one())
+
+    # chores_due_soon_total
+    due_soon_days = await _get_due_soon_days(db)
+    due_soon_cutoff = today + timedelta(days=due_soon_days)
+    due_soon = await db.execute(
+        select(func.count()).select_from(Chore).where(
+            Chore.next_due <= due_soon_cutoff
+        )
+    )
+    _chores_due_soon_total.set(due_soon.scalar_one())
+
+    # chores_due_now_by_person — due chores grouped by current_assignee
+    by_person = await db.execute(
+        select(Chore.current_assignee, func.count())
+        .where(Chore.state == "due")
+        .group_by(Chore.current_assignee)
+    )
+    _chores_due_now_by_person.clear()
+    for assignee, count in by_person.all():
+        person_label = assignee or "unassigned"
+        _chores_due_now_by_person.labels(person=person_label).set(count)
+
+    # people_total
+    people_count = await db.execute(select(func.count()).select_from(Person))
+    _people_total.set(people_count.scalar_one())
+
+    # points_awarded_total
+    points_sum = await db.execute(select(func.sum(PointsLog.points)))
+    _points_awarded_total.set(points_sum.scalar_one() or 0)
+
+    # chore_completions_by_person — 7d and 30d windows
+    _chore_completions_by_person.clear()
+    for window_label, days in [("7d", 7), ("30d", 30)]:
+        cutoff = now - timedelta(days=days)
+        completions = await db.execute(
+            select(PointsLog.person, func.count())
+            .where(PointsLog.completed_at >= cutoff)
+            .group_by(PointsLog.person)
+        )
+        for person, count in completions.all():
+            _chore_completions_by_person.labels(person=person, window=window_label).set(count)
+
+
+@router.get("/metrics", include_in_schema=False)
+async def metrics(db: AsyncSession = Depends(get_db)):
+    """Return Prometheus metrics in text format.
+
+    Public endpoint — no authentication required. Process metrics are
+    collected automatically by prometheus_client; application metrics are
+    queried from the database on each scrape.
+    """
+    await _collect_metrics(db)
+    data = prometheus_client.generate_latest()
+    return Response(
+        content=data,
+        media_type=prometheus_client.CONTENT_TYPE_LATEST,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,8 @@ apscheduler>=3.10.4
 pydantic-settings>=2.2.0
 passlib[bcrypt]>=1.7.4
 python-jose[cryptography]>=3.3.0
+prometheus-client>=0.20.0
+starlette-prometheus>=0.10.0
 # test deps
 pytest>=8.0.0
 pytest-asyncio>=0.23.0

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,172 @@
+"""Tests for the Prometheus metrics endpoint."""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+async def test_prometheus_client_importable():
+    """prometheus_client must be installed as a dependency."""
+    import prometheus_client  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_starlette_prometheus_importable():
+    """starlette_prometheus must be installed as a dependency."""
+    import starlette_prometheus  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_200(client: AsyncClient):
+    """GET /metrics returns 200 with Prometheus text format."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_content_type(client: AsyncClient):
+    """GET /metrics returns Prometheus text format content type."""
+    response = await client.get("/metrics")
+    assert "text/plain" in response.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_no_auth_required(client: AsyncClient):
+    """GET /metrics is public — no authentication required."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_chores_total_gauge_present(client: AsyncClient, db):
+    """chores_total gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chores_total" in response.content
+
+
+@pytest.mark.asyncio
+async def test_chores_due_now_total_gauge_present(client: AsyncClient, db):
+    """chores_due_now_total gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chores_due_now_total" in response.content
+
+
+@pytest.mark.asyncio
+async def test_chores_due_soon_total_gauge_present(client: AsyncClient, db):
+    """chores_due_soon_total gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chores_due_soon_total" in response.content
+
+
+@pytest.mark.asyncio
+async def test_chores_due_now_by_person_gauge_present(client: AsyncClient, db):
+    """chores_due_now_by_person gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chores_due_now_by_person" in response.content
+
+
+@pytest.mark.asyncio
+async def test_people_total_gauge_present(client: AsyncClient, db):
+    """people_total gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"people_total" in response.content
+
+
+@pytest.mark.asyncio
+async def test_points_awarded_total_gauge_present(client: AsyncClient, db):
+    """points_awarded_total gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"points_awarded_total" in response.content
+
+
+@pytest.mark.asyncio
+async def test_chore_completions_by_person_gauge_present(client: AsyncClient, db):
+    """chore_completions_by_person gauge is present in metrics output."""
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chore_completions_by_person" in response.content
+
+
+@pytest.mark.asyncio
+async def test_chores_total_reflects_db_state(client: AsyncClient, db):
+    """chores_total gauge values reflect actual chore counts in the DB."""
+    from app.models import Chore
+    from datetime import date
+
+    # Add two chores: one 'due', one 'completed'
+    db.add(Chore(
+        name="Vacuum",
+        schedule_type="weekly",
+        state="due",
+        disabled=False,
+        next_due=date.today(),
+    ))
+    db.add(Chore(
+        name="Mop",
+        schedule_type="weekly",
+        state="completed",
+        disabled=False,
+        next_due=date.today(),
+    ))
+    await db.commit()
+
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    text = response.text
+    # Should see both states in the output
+    assert "chores_total" in text
+
+
+@pytest.mark.asyncio
+async def test_people_total_reflects_db_count(client: AsyncClient, db):
+    """people_total gauge value matches DB person count."""
+    from app.models import Person
+
+    db.add(Person(name="Alice", username="alice", password_hash="hash"))
+    db.add(Person(name="Bob", username="bob", password_hash="hash"))
+    await db.commit()
+
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    text = response.text
+    # people_total should be in output
+    assert "people_total" in text
+
+
+@pytest.mark.asyncio
+async def test_chore_completions_by_person_has_window_labels(client: AsyncClient, db):
+    """chore_completions_by_person includes window labels (7d, 30d)."""
+    from app.models import Person, PointsLog
+    from datetime import datetime, timezone
+
+    person = Person(name="Alice", username="alice2", password_hash="hash")
+    db.add(person)
+    await db.flush()
+
+    db.add(PointsLog(
+        person="alice2",
+        points=10,
+        chore_id=1,
+        completed_at=datetime.now(timezone.utc),
+    ))
+    await db.commit()
+
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    assert b"chore_completions_by_person" in response.content
+
+
+@pytest.mark.asyncio
+async def test_http_request_metrics_present(client: AsyncClient):
+    """starlette_prometheus middleware injects HTTP request count metrics."""
+    # Make a request first so metrics get populated
+    await client.get("/health")
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+    # starlette-prometheus registers starlette_requests_total
+    assert b"starlette_requests" in response.content

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -190,6 +190,35 @@ Monitor via docker stats:
 docker stats
 ```
 
+### Prometheus Scraping
+
+The backend exposes a Prometheus metrics endpoint at `GET /metrics` (public, no authentication).
+
+Example `prometheus.yml` scrape configuration:
+
+```yaml
+scrape_configs:
+  - job_name: chores-web
+    static_configs:
+      - targets:
+          - backend:8000   # use your backend host/port
+    metrics_path: /metrics
+    scrape_interval: 30s
+```
+
+Available application metrics:
+- `chores_total{state, disabled}` — chore counts by state and disabled flag
+- `chores_due_now_total` — chores currently due
+- `chores_due_soon_total` — chores due within the configured `due_soon_days` window
+- `chores_due_now_by_person{person}` — due chores per assignee
+- `people_total` — registered user count
+- `points_awarded_total` — total points across all PointsLog entries
+- `chore_completions_by_person{person, window}` — completions per person for 7d and 30d windows
+
+Process and HTTP request metrics are also included automatically.
+
+No Docker Compose Prometheus service is bundled — add your own Prometheus container or use an external Prometheus instance pointing at the backend.
+
 ## Troubleshooting
 
 ### Port Already in Use

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -156,6 +156,30 @@ Frontend tests: 205/205 passing ✓
 Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
 ```
 
+## Observability
+
+### Metrics Endpoint
+
+The backend exposes a Prometheus-compatible metrics endpoint:
+
+**`GET /metrics`** — Returns metrics in Prometheus text format. Public, no authentication required.
+
+Available metrics:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `chores_total` | Gauge | `state`, `disabled` | Total chores grouped by state and disabled flag |
+| `chores_due_now_total` | Gauge | — | Chores where `state='due'` |
+| `chores_due_soon_total` | Gauge | — | Chores where `next_due <= today + due_soon_days` |
+| `chores_due_now_by_person` | Gauge | `person` | Due chores grouped by current assignee |
+| `people_total` | Gauge | — | Total user count |
+| `points_awarded_total` | Gauge | — | Sum of all PointsLog entries |
+| `chore_completions_by_person` | Gauge | `person`, `window` | Completions in 7d and 30d windows |
+
+Process metrics (CPU, memory, file descriptors) are provided automatically by `prometheus_client`.
+
+HTTP request metrics (request count, duration histogram by path) are provided by `starlette-prometheus` middleware.
+
 ## API Development
 
 ### Adding a New Endpoint


### PR DESCRIPTION
## Summary

- Add `prometheus-client` and `starlette-prometheus` to backend dependencies
- Register `PrometheusMiddleware` in FastAPI app for automatic HTTP request metrics
- Create `routers/metrics.py` with public `GET /metrics` endpoint (no auth required)
- Expose application gauges: `chores_total`, `chores_due_now_total`, `chores_due_soon_total`, `chores_due_now_by_person`, `people_total`, `points_awarded_total`, `chore_completions_by_person` (7d/30d windows)
- Update `DEVELOPER.md` with metrics endpoint reference table
- Update `DEPLOYMENT.md` with Prometheus scrape config example

## Issue

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)