### PR TITLE
test: add realistic seeded data to catch identifier mismatch bugs (#211)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,20 +24,59 @@ async def setup_db():
 
 @pytest_asyncio.fixture
 async def seeded_db(db):
-    from app.models import Person, Settings
+    from datetime import datetime, timedelta, timezone
+    from app.models import Chore, Person, PointsLog, Settings
+    from app.security import hash_password
 
     # Enable auth in tests
     settings = Settings(key="auth_enabled", value="true")
     db.add(settings)
 
     db.add_all([
-        Person(name="Derek", username="derek", password_hash="hash1", is_admin=False),
+        Person(name="Derek", username="derek", password_hash=hash_password("derek_pass"), is_admin=True),
         Person(name="Amy", username="amy", password_hash="hash2", is_admin=False),
         Person(name="Connor", username="connor", password_hash="hash3", is_admin=False),
         Person(name="Lucas", username="lucas", password_hash="hash4", is_admin=False),
     ])
     await db.commit()
+
+    # Add one Chore so seeded_client tests can reference a real chore
+    chore = Chore(
+        name="Seeded Chore",
+        schedule_type="interval",
+        schedule_config={"days": 7},
+        assignment_type="open",
+        eligible_people=[],
+        points=10,
+    )
+    db.add(chore)
+    await db.commit()
+
+    # Add two PointsLog entries for derek: 3d ago = 10pts, 15d ago = 20pts
+    now = datetime.now(timezone.utc)
+    db.add_all([
+        PointsLog(person="derek", chore_id=chore.id, points=10, completed_at=now - timedelta(days=3)),
+        PointsLog(person="derek", chore_id=chore.id, points=20, completed_at=now - timedelta(days=15)),
+    ])
+    await db.commit()
+
     yield db
+
+
+@pytest_asyncio.fixture
+async def seeded_client(seeded_db):
+    async def override_get_db():
+        yield seeded_db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        login_r = await ac.post("/auth/login", json={"username": "derek", "password": "derek_pass"})
+        token = login_r.json()["access_token"]
+        ac.headers = {"Authorization": f"Bearer {token}"}
+        yield ac, seeded_db
+
+    app.dependency_overrides.clear()
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -699,52 +699,48 @@ class TestPointsAPI:
         assert summary[0]["points_30d"] == 0
 
     @pytest.mark.asyncio
-    async def test_points_summary_includes_all_people(self, authenticated_client):
-        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
-        await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
-        r = await authenticated_client.get("/points/summary")
+    async def test_points_summary_includes_all_people(self, seeded_client):
+        ac, db = seeded_client
+        r = await ac.get("/points/summary")
         assert r.status_code == 200
         names = [e["person"] for e in r.json()]
-        assert "alice" in names
-        assert "bob" in names
-        assert "testuser" in names
+        assert "derek" in names
+        assert "amy" in names
+        assert "connor" in names
+        assert "lucas" in names
 
     @pytest.mark.asyncio
-    async def test_points_summary_counts_recent(self, authenticated_client):
-        await authenticated_client.post("/people", json={"name": "Alice", "username": "alice"})
-        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
-        chore_id = r.json()["id"]
-        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
-
-        r = await authenticated_client.get("/points/summary")
-        testuser = next(e for e in r.json() if e["person"] == "testuser")
-        assert testuser["points_7d"] == 5
-        assert testuser["points_30d"] == 5
+    async def test_points_summary_counts_recent(self, seeded_client):
+        ac, db = seeded_client
+        # seeded_db provides derek: 10pts 3d ago (within 7d), 20pts 15d ago (within 30d only)
+        r = await ac.get("/points/summary")
+        assert r.status_code == 200
+        derek = next(e for e in r.json() if e["person"] == "derek")
+        assert derek["points_7d"] == 10
+        assert derek["points_30d"] == 30
 
     @pytest.mark.asyncio
-    async def test_points_summary_zero_for_no_activity(self, authenticated_client):
-        await authenticated_client.post("/people", json={"name": "Bob", "username": "bob"})
-        r = await authenticated_client.get("/points/summary")
-        bob = next(e for e in r.json() if e["person"] == "bob")
-        assert bob["points_7d"] == 0
-        assert bob["points_30d"] == 0
+    async def test_points_summary_zero_for_no_activity(self, seeded_client):
+        ac, db = seeded_client
+        # Amy has no PointsLog entries in seeded_db
+        r = await ac.get("/points/summary")
+        assert r.status_code == 200
+        amy = next(e for e in r.json() if e["person"] == "amy")
+        assert amy["points_7d"] == 0
+        assert amy["points_30d"] == 0
 
     @pytest.mark.asyncio
-    async def test_user_stats_returns_nonzero_after_completion(self, authenticated_client):
-        """user_stats should return correct non-zero points_7d and points_30d."""
-        r = await authenticated_client.post("/chores", json=WEEKLY_CHORE)
-        chore_id = r.json()["id"]
-        await authenticated_client.post(f"/chores/{chore_id}/mark-due")
-        await authenticated_client.post(f"/chores/{chore_id}/complete", json={})
-
-        r = await authenticated_client.get("/points/stats/testuser")
+    async def test_user_stats_returns_nonzero_after_completion(self, seeded_client):
+        """user_stats should return correct non-zero points_7d and points_30d using seeded data."""
+        ac, db = seeded_client
+        # seeded_db provides derek: 10pts 3d ago (within 7d), 20pts 15d ago (within 30d only)
+        r = await ac.get("/points/stats/derek")
         assert r.status_code == 200
         data = r.json()
-        assert data["points_7d"] == 5
-        assert data["points_30d"] == 5
-        assert data["total_points"] == 5
-        assert data["display_points"] == 5
+        assert data["points_7d"] == 10
+        assert data["points_30d"] == 30
+        assert data["total_points"] == 30
+        assert data["display_points"] == 30
 
     @pytest.mark.asyncio
     async def test_user_stats_excludes_old_entries(self, authenticated_client, db):
@@ -1061,3 +1057,5 @@ class TestUserLogAPI:
         reassign_log = next(e for e in logs if e["action"] == "reassigned")
         # Should be the requesting user, not "system"
         assert reassign_log["person"] == "testuser"
+
+

--- a/frontend/src/__tests__/Dashboard.test.jsx
+++ b/frontend/src/__tests__/Dashboard.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, within, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
@@ -10,7 +10,11 @@ vi.mock("../api/client");
 
 const TODAY = new Date().toISOString().split("T")[0];
 
-const PEOPLE = [{ id: 1, name: "Alice", username: "alice" }, { id: 2, name: "Bob", username: "bob" }];
+const PEOPLE = [
+  { id: 1, name: "Alice", username: "alice" },
+  { id: 2, name: "Bob", username: "bob" },
+  { id: 3, name: "Carol", username: "carol" },
+];
 
 const CHORES = [
   {
@@ -74,8 +78,20 @@ describe("Dashboard", () => {
 
   it("shows points summary on each card", async () => {
     wrap(<Dashboard />);
-    await waitFor(() => expect(screen.getByText("10")).toBeInTheDocument());
-    expect(screen.getByText("25")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Alice", { selector: ".uc-name" })).toBeInTheDocument());
+    const aliceCard = screen.getByText("Alice", { selector: ".uc-name" }).closest(".user-card");
+    const alicePointsCols = within(aliceCard).getAllByText(/./, { selector: ".uc-points-value span:first-child" });
+    expect(alicePointsCols[0]).toHaveTextContent("10");
+    expect(alicePointsCols[1]).toHaveTextContent("25");
+  });
+
+  it("shows zero points for person not in summary (Carol)", async () => {
+    wrap(<Dashboard />);
+    await waitFor(() => expect(screen.getByText("Carol", { selector: ".uc-name" })).toBeInTheDocument());
+    const carolCard = screen.getByText("Carol", { selector: ".uc-name" }).closest(".user-card");
+    const carolPointsCols = within(carolCard).getAllByText(/./, { selector: ".uc-points-value span:first-child" });
+    expect(carolPointsCols[0]).toHaveTextContent("0");
+    expect(carolPointsCols[1]).toHaveTextContent("0");
   });
 
   it("shows empty state when no people", async () => {


### PR DESCRIPTION
## Summary

- Extend `seeded_db` fixture with a `Chore` record and two `PointsLog` entries for derek (10pts 3 days ago, 20pts 15 days ago), enabling assertions against known non-zero values
- Add `seeded_client` fixture that composes auth + seeded data, logging in as derek and yielding `(ac, seeded_db)` for use in endpoint tests
- Migrate four backend points tests (`test_points_summary_includes_all_people`, `test_points_summary_counts_recent`, `test_points_summary_zero_for_no_activity`, `test_user_stats_returns_nonzero_after_completion`) from ad-hoc inline person/chore creation to `seeded_client`, using persons where name differs from username to surface any identifier mismatch bugs
- Add Carol to `Dashboard.test.jsx` `PEOPLE` mock (no summary entry) and assert her card renders `0` for both point fields, covering the "not in summary" code path
- Replace weak global `screen.getByText("10")` assertion with `within(aliceCard)` scoped per-user point assertions

## Issue

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)