### PR TITLE
feat: add upgrade regression test infrastructure (#207)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Resolve latest published GHCR tag
         id: prev-tag
         run: |
-          PREV_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          PREV_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' | sed 's/^v//')
           if [ -z "$PREV_TAG" ]; then
             echo "No previous release found; skipping upgrade regression test" >&2
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,14 +146,12 @@ jobs:
         env:
           PREV_TAG: ${{ steps.prev-tag.outputs.prev_tag }}
         run: |
-          docker compose -f docker-compose.test-upgrade.yml up \
-            --build \
-            --abort-on-container-exit \
-            --exit-code-from validate
+          docker compose -f docker-compose.test-upgrade.yml up --build -d
+          docker compose -f docker-compose.test-upgrade.yml wait validate
       - name: Collect validate service logs on failure
         if: failure()
         run: |
-          docker compose -f docker-compose.test-upgrade.yml logs validate || true
+          docker compose -f docker-compose.test-upgrade.yml logs new-backend validate || true
       - name: Tear down upgrade test containers
         if: always()
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,47 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  upgrade-regression:
+    runs-on: ubuntu-latest
+    needs: [frontend-tests, backend-tests]
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve latest published GHCR tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release found; skipping upgrade regression test" >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Previous release tag: $PREV_TAG"
+            echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run upgrade regression test
+        if: steps.prev-tag.outputs.skip == 'false'
+        env:
+          PREV_TAG: ${{ steps.prev-tag.outputs.prev_tag }}
+        run: |
+          docker compose -f docker-compose.test-upgrade.yml up \
+            --build \
+            --abort-on-container-exit \
+            --exit-code-from validate
+      - name: Collect validate service logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.test-upgrade.yml logs validate || true
+      - name: Tear down upgrade test containers
+        if: always()
+        run: |
+          docker compose -f docker-compose.test-upgrade.yml down --volumes --remove-orphans || true

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,17 +1,62 @@
-"""Seed initial people and chores. Run once after first deploy."""
+"""Seed initial people and chores with comprehensive activity data.
+
+Run once after first deploy to populate the database with realistic data
+for development and upgrade regression testing.
+
+Usage:
+    python seed.py [--base-url http://localhost:8000]
+
+The script:
+1. Authenticates as admin (auto-creates admin on first login)
+2. Creates People
+3. Creates Chores
+4. Seeds Completions, Skips, Reassignments, and Amendments (schedule/point updates)
+"""
 import asyncio
+import sys
 import httpx
 
 BASE = "http://localhost:8000"
 
 
-async def seed():
-    async with httpx.AsyncClient(base_url=BASE, timeout=10) as c:
-        for name in ["Derek", "Amy", "Connor", "Lucas"]:
-            r = await c.post("/people", json={"name": name})
-            print(f"Person {name}: {r.status_code}")
+async def seed(base_url: str = BASE) -> None:
+    async with httpx.AsyncClient(base_url=base_url, timeout=30) as c:
+        # ------------------------------------------------------------------
+        # Step 1: Login (auto-creates admin on first login if no users exist)
+        # ------------------------------------------------------------------
+        print("Logging in as admin...")
+        login_r = await c.post("/auth/login", json={"username": "admin", "password": "adminpass123"})
+        if login_r.status_code != 200:
+            print(f"Login failed: {login_r.status_code} {login_r.text}", file=sys.stderr)
+            sys.exit(1)
+        token = login_r.json()["access_token"]
+        c.headers.update({"Authorization": f"Bearer {token}"})
+        print("Login OK")
 
-        chores = [
+        # ------------------------------------------------------------------
+        # Step 2: Create People
+        # ------------------------------------------------------------------
+        people = [
+            {"name": "Derek", "username": "derek", "password": "derek_pass"},
+            {"name": "Amy",   "username": "amy",   "password": "amy_pass"},
+            {"name": "Connor","username": "connor", "password": "connor_pass"},
+            {"name": "Lucas", "username": "lucas",  "password": "lucas_pass"},
+        ]
+        person_ids: dict[str, int] = {}
+        for p in people:
+            r = await c.post("/people", json=p)
+            if r.status_code in (200, 201):
+                person_ids[p["name"]] = r.json()["id"]
+                print(f"Person {p['name']}: {r.status_code}")
+            elif r.status_code == 409:
+                print(f"Person {p['name']}: already exists, skipping")
+            else:
+                print(f"Person {p['name']}: {r.status_code} {r.text}", file=sys.stderr)
+
+        # ------------------------------------------------------------------
+        # Step 3: Create Chores
+        # ------------------------------------------------------------------
+        chores_data = [
             {
                 "name": "Vacuum downstairs",
                 "schedule_type": "weekly",
@@ -34,6 +79,7 @@ async def seed():
                 "schedule_config": {"days": 14},
                 "assignment_type": "fixed",
                 "assignee": "Derek",
+                "eligible_people": [],
                 "points": 4,
             },
             {
@@ -46,9 +92,92 @@ async def seed():
             },
         ]
 
-        for chore in chores:
+        chore_ids: dict[str, int] = {}
+        for chore in chores_data:
             r = await c.post("/chores", json=chore)
-            print(f"Chore {chore['name']}: {r.status_code}")
+            if r.status_code in (200, 201):
+                chore_ids[chore["name"]] = r.json()["id"]
+                print(f"Chore '{chore['name']}': {r.status_code}")
+            elif r.status_code == 409:
+                # Already exists — fetch by listing
+                print(f"Chore '{chore['name']}': already exists, skipping")
+            else:
+                print(f"Chore '{chore['name']}': {r.status_code} {r.text}", file=sys.stderr)
+
+        if not chore_ids:
+            print("No chores created; skipping activity seeding", file=sys.stderr)
+            return
+
+        # ------------------------------------------------------------------
+        # Step 4: Completions — complete each chore once
+        # ------------------------------------------------------------------
+        print("\nSeeding completions...")
+        for chore_name, chore_id in chore_ids.items():
+            # Force state to due before completing
+            await c.put(f"/chores/{chore_id}", json={"state": "due"})
+            r = await c.post(f"/chores/{chore_id}/complete", json={"completed_by": "admin"})
+            print(f"  Complete '{chore_name}': {r.status_code}")
+
+        # ------------------------------------------------------------------
+        # Step 5: Skips — skip the open chore
+        # ------------------------------------------------------------------
+        print("\nSeeding skips...")
+        trash_id = chore_ids.get("Take out trash")
+        if trash_id:
+            await c.put(f"/chores/{trash_id}", json={"state": "due"})
+            r = await c.post(f"/chores/{trash_id}/skip")
+            print(f"  Skip 'Take out trash': {r.status_code}")
+
+        # Also skip the lawn chore
+        lawn_id = chore_ids.get("Mow lawn")
+        if lawn_id:
+            await c.put(f"/chores/{lawn_id}", json={"state": "due"})
+            r = await c.post(f"/chores/{lawn_id}/skip")
+            print(f"  Skip 'Mow lawn': {r.status_code}")
+
+        # ------------------------------------------------------------------
+        # Step 6: Reassignments — reassign the fixed chore to another person
+        # ------------------------------------------------------------------
+        print("\nSeeding reassignments...")
+        vacuum_id = chore_ids.get("Vacuum downstairs")
+        if vacuum_id:
+            # Get current chore state to know who it's assigned to
+            chore_r = await c.get(f"/chores/{vacuum_id}")
+            if chore_r.status_code == 200:
+                current = chore_r.json().get("current_assignee")
+                # Reassign to the next person in the rotation
+                eligible = ["Derek", "Amy", "Connor", "Lucas"]
+                if current in eligible:
+                    idx = eligible.index(current)
+                    new_assignee = eligible[(idx + 1) % len(eligible)]
+                else:
+                    new_assignee = "Amy"
+                r = await c.post(f"/chores/{vacuum_id}/reassign", json={"assignee": new_assignee})
+                print(f"  Reassign 'Vacuum downstairs' → {new_assignee}: {r.status_code}")
+
+        # ------------------------------------------------------------------
+        # Step 7: Amendments — update schedule or points on chores
+        # ------------------------------------------------------------------
+        print("\nSeeding amendments...")
+        # Update points on 'Clean bathrooms'
+        bath_id = chore_ids.get("Clean bathrooms")
+        if bath_id:
+            r = await c.put(f"/chores/{bath_id}", json={"points": 6})
+            print(f"  Amend 'Clean bathrooms' points → 6: {r.status_code}")
+
+        # Update schedule interval on 'Mow lawn'
+        if lawn_id:
+            r = await c.put(f"/chores/{lawn_id}", json={
+                "schedule_type": "interval",
+                "schedule_config": {"days": 10},
+            })
+            print(f"  Amend 'Mow lawn' schedule → interval/10d: {r.status_code}")
+
+        print("\nSeed complete.")
 
 
-asyncio.run(seed())
+if __name__ == "__main__":
+    base_url = BASE
+    if len(sys.argv) > 1 and sys.argv[1] == "--base-url":
+        base_url = sys.argv[2]
+    asyncio.run(seed(base_url))

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,0 +1,243 @@
+"""Tests for the seed.py script logic.
+
+These tests verify that seed.py:
+- Performs a login step (uses auth token for subsequent requests)
+- Seeds comprehensive entity/action data: People, Chores, Completions, Skips,
+  Reassignments, and Amendments (schedule/point updates)
+
+Tests use a live ASGI test client against an in-memory SQLite DB to exercise the
+same API paths that seed.py calls, confirming those paths produce the expected data.
+"""
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.main import app
+from app.models import Base, ChoreLog, PointsLog, Person, Chore
+from app.database import get_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SEED_DB_URL = "sqlite+aiosqlite:///:memory:"
+seed_engine = create_async_engine(SEED_DB_URL, connect_args={"check_same_thread": False})
+SeedSession = async_sessionmaker(seed_engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def seed_db():
+    async with seed_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with SeedSession() as session:
+        yield session
+    async with seed_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def seed_client(seed_db):
+    async def override_get_db():
+        yield seed_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac, seed_db
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the seed logic inline (mirrors what seed.py will do)
+# ---------------------------------------------------------------------------
+
+async def _run_seed(ac: AsyncClient) -> dict:
+    """Execute the seed workflow against the given client. Returns login token."""
+    # Login step (first login auto-creates admin)
+    login_r = await ac.post("/auth/login", json={"username": "admin", "password": "adminpass123"})
+    assert login_r.status_code == 200, f"Login failed: {login_r.text}"
+    token = login_r.json()["access_token"]
+    ac.headers = {"Authorization": f"Bearer {token}"}
+    return {"token": token}
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1a: seed.py performs a login step and obtains a token
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_performs_login(seed_client):
+    """Seed must start with a login step that yields a usable auth token."""
+    ac, db = seed_client
+    result = await _run_seed(ac)
+    # Token must be non-empty
+    assert result["token"], "seed login did not return a token"
+
+    # Token must allow authenticated requests
+    chores_r = await ac.get("/chores")
+    assert chores_r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1b: seed.py creates People and Chores
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_creates_people_and_chores(seed_client):
+    """Seed must create multiple people and chores."""
+    ac, db = seed_client
+    await _run_seed(ac)
+
+    # Create people via API (as seed.py does)
+    for name in ["Derek", "Amy", "Connor", "Lucas"]:
+        r = await ac.post("/people", json={"name": name, "username": name.lower(), "password": "pass1234"})
+        assert r.status_code in (200, 201), f"Person creation failed for {name}: {r.text}"
+
+    # Verify people exist
+    result = await db.execute(select(Person))
+    people = result.scalars().all()
+    # admin + 4 seeded people
+    assert len(people) >= 4, f"Expected at least 4 people, got {len(people)}"
+
+    # Create a chore
+    chore_data = {
+        "name": "Vacuum downstairs",
+        "schedule_type": "weekly",
+        "schedule_config": {"days": ["mon", "thu"]},
+        "assignment_type": "rotating",
+        "eligible_people": ["Derek", "Amy", "Connor", "Lucas"],
+        "points": 3,
+    }
+    r = await ac.post("/chores", json=chore_data)
+    assert r.status_code == 201, f"Chore creation failed: {r.text}"
+
+    result = await db.execute(select(Chore))
+    chores = result.scalars().all()
+    assert len(chores) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1c: seed.py seeds Completions (PointsLog entries created)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_creates_completions(seed_client):
+    """Seed must complete at least one chore, producing a PointsLog entry."""
+    ac, db = seed_client
+    await _run_seed(ac)
+
+    # Create person and chore
+    await ac.post("/people", json={"name": "Derek", "username": "derek2", "password": "pass1234"})
+    chore_r = await ac.post("/chores", json={
+        "name": "Test Completion Chore",
+        "schedule_type": "interval",
+        "schedule_config": {"days": 7},
+        "assignment_type": "open",
+        "eligible_people": [],
+        "points": 5,
+    })
+    chore_id = chore_r.json()["id"]
+
+    # Force state to due so complete action is possible
+    await ac.put(f"/chores/{chore_id}", json={"state": "due"})
+
+    r = await ac.post(f"/chores/{chore_id}/complete", json={"completed_by": "admin"})
+    assert r.status_code == 200, f"Complete failed: {r.text}"
+
+    result = await db.execute(select(PointsLog))
+    entries = result.scalars().all()
+    assert len(entries) >= 1, "No PointsLog entries after completion"
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1d: seed.py seeds Skips (ChoreLog entries with action=skipped)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_creates_skips(seed_client):
+    """Seed must skip at least one chore, producing a ChoreLog entry with action='skipped'."""
+    ac, db = seed_client
+    await _run_seed(ac)
+
+    chore_r = await ac.post("/chores", json={
+        "name": "Skip Test Chore",
+        "schedule_type": "interval",
+        "schedule_config": {"days": 7},
+        "assignment_type": "open",
+        "eligible_people": [],
+        "points": 2,
+    })
+    chore_id = chore_r.json()["id"]
+    await ac.put(f"/chores/{chore_id}", json={"state": "due"})
+
+    r = await ac.post(f"/chores/{chore_id}/skip")
+    assert r.status_code == 200, f"Skip failed: {r.text}"
+
+    result = await db.execute(select(ChoreLog).where(ChoreLog.action == "skipped"))
+    entries = result.scalars().all()
+    assert len(entries) >= 1, "No ChoreLog skip entries after skip action"
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1e: seed.py seeds Reassignments (ChoreLog action=reassigned)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_creates_reassignments(seed_client):
+    """Seed must reassign at least one chore, producing a ChoreLog entry with action='reassigned'."""
+    ac, db = seed_client
+    await _run_seed(ac)
+
+    # Create two people for reassignment
+    await ac.post("/people", json={"name": "Alice", "username": "alice", "password": "pass1234"})
+    await ac.post("/people", json={"name": "Bob", "username": "bob", "password": "pass1234"})
+
+    chore_r = await ac.post("/chores", json={
+        "name": "Reassign Test Chore",
+        "schedule_type": "interval",
+        "schedule_config": {"days": 7},
+        "assignment_type": "fixed",
+        "assignee": "Alice",
+        "eligible_people": [],
+        "points": 2,
+    })
+    chore_id = chore_r.json()["id"]
+
+    r = await ac.post(f"/chores/{chore_id}/reassign", json={"assignee": "Bob"})
+    assert r.status_code == 200, f"Reassign failed: {r.text}"
+
+    result = await db.execute(select(ChoreLog).where(ChoreLog.action == "reassigned"))
+    entries = result.scalars().all()
+    assert len(entries) >= 1, "No ChoreLog reassignment entries after reassign action"
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1f: seed.py seeds Amendments (PUT /chores/{id} updating schedule/points)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_creates_amendments(seed_client):
+    """Seed must amend at least one chore (update schedule or points via PUT),
+    producing a ChoreLog entry with action='updated'."""
+    ac, db = seed_client
+    await _run_seed(ac)
+
+    chore_r = await ac.post("/chores", json={
+        "name": "Amendment Test Chore",
+        "schedule_type": "interval",
+        "schedule_config": {"days": 7},
+        "assignment_type": "open",
+        "eligible_people": [],
+        "points": 3,
+    })
+    chore_id = chore_r.json()["id"]
+
+    # Amend points and schedule
+    r = await ac.put(f"/chores/{chore_id}", json={"points": 5})
+    assert r.status_code == 200, f"Amendment (PUT) failed: {r.text}"
+
+    result = await db.execute(select(ChoreLog).where(ChoreLog.action == "updated"))
+    entries = result.scalars().all()
+    assert len(entries) >= 1, "No ChoreLog 'updated' entries after amending chore"

--- a/backend/validate_upgrade.py
+++ b/backend/validate_upgrade.py
@@ -1,0 +1,253 @@
+"""Upgrade regression validation script.
+
+Validates that data seeded against the previous release is intact after the new
+backend starts against the same Postgres volume. Exits non-zero on any failure,
+which fails the CI job.
+
+Checks performed:
+  API assertions:
+    - /health returns {"status": "ok"}
+    - /people returns >= 4 people (Derek, Amy, Connor, Lucas + admin)
+    - /chores returns >= 4 chores
+    - /points (leaderboard) returns entries (completions produce PointsLog rows)
+    - /log returns entries with actions: completed, skipped, reassigned, updated
+
+  Raw SQL checks (via DATABASE_URL):
+    - points_log rows >= expected completions count
+    - chore_log FK integrity: all chore_log.chore_id reference valid chores.id
+
+Usage:
+    python validate_upgrade.py [--base-url http://localhost:8000]
+
+Environment:
+    DATABASE_URL — Postgres connection string (required for SQL checks)
+"""
+import asyncio
+import os
+import sys
+import httpx
+
+BASE = "http://localhost:8000"
+FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    print(f"  FAIL: {msg}", file=sys.stderr)
+    FAILURES.append(msg)
+
+
+def ok(msg: str) -> None:
+    print(f"  OK:   {msg}")
+
+
+# ---------------------------------------------------------------------------
+# API assertions
+# ---------------------------------------------------------------------------
+
+async def check_health(c: httpx.AsyncClient) -> None:
+    print("Checking /health...")
+    r = await c.get("/health")
+    if r.status_code != 200:
+        fail(f"/health returned {r.status_code}")
+        return
+    data = r.json()
+    if data.get("status") != "ok":
+        fail(f"/health returned unexpected body: {data}")
+    else:
+        ok("/health status=ok")
+
+
+async def check_people(c: httpx.AsyncClient) -> None:
+    print("Checking /people...")
+    r = await c.get("/people")
+    if r.status_code != 200:
+        fail(f"/people returned {r.status_code}")
+        return
+    people = r.json()
+    names = [p["name"] for p in people]
+    expected_names = ["Derek", "Amy", "Connor", "Lucas"]
+    for name in expected_names:
+        if name not in names:
+            fail(f"/people missing expected person: {name}")
+        else:
+            ok(f"/people contains {name}")
+    if len(people) < 4:
+        fail(f"/people returned only {len(people)} people (expected >= 4)")
+    else:
+        ok(f"/people count={len(people)}")
+
+
+async def check_chores(c: httpx.AsyncClient) -> int:
+    """Returns number of chores found."""
+    print("Checking /chores...")
+    r = await c.get("/chores")
+    if r.status_code != 200:
+        fail(f"/chores returned {r.status_code}")
+        return 0
+    chores = r.json()
+    expected_names = ["Vacuum downstairs", "Clean bathrooms", "Mow lawn", "Take out trash"]
+    for name in expected_names:
+        if not any(ch["name"] == name for ch in chores):
+            fail(f"/chores missing expected chore: {name}")
+        else:
+            ok(f"/chores contains '{name}'")
+    if len(chores) < 4:
+        fail(f"/chores returned only {len(chores)} chores (expected >= 4)")
+    else:
+        ok(f"/chores count={len(chores)}")
+    return len(chores)
+
+
+async def check_points(c: httpx.AsyncClient) -> None:
+    print("Checking /points (leaderboard)...")
+    r = await c.get("/points")
+    if r.status_code != 200:
+        fail(f"/points returned {r.status_code}")
+        return
+    entries = r.json()
+    if len(entries) == 0:
+        fail("/points leaderboard is empty (expected completions to produce PointsLog entries)")
+    else:
+        ok(f"/points leaderboard has {len(entries)} entries")
+
+
+async def check_activity_log(c: httpx.AsyncClient) -> None:
+    print("Checking /log for expected action types...")
+    r = await c.get("/log")
+    if r.status_code != 200:
+        fail(f"/log returned {r.status_code}")
+        return
+    entries = r.json()
+    actions_found = {entry["action"] for entry in entries}
+
+    required_actions = ["completed", "skipped", "reassigned", "updated"]
+    for action in required_actions:
+        if action not in actions_found:
+            fail(f"/log missing entries with action='{action}'")
+        else:
+            ok(f"/log contains action='{action}'")
+
+    ok(f"/log total entries: {len(entries)}")
+
+
+# ---------------------------------------------------------------------------
+# Raw SQL checks
+# ---------------------------------------------------------------------------
+
+async def check_sql_integrity() -> None:
+    """Run raw SQL checks against Postgres via asyncpg."""
+    db_url = os.environ.get("DATABASE_URL", "")
+    if not db_url:
+        print("Skipping SQL checks: DATABASE_URL not set")
+        return
+
+    try:
+        import asyncpg
+    except ImportError:
+        print("Skipping SQL checks: asyncpg not available")
+        return
+
+    # Convert SQLAlchemy URL to asyncpg URL
+    conn_url = db_url.replace("postgresql+asyncpg://", "postgresql://")
+
+    print("Checking SQL integrity...")
+    try:
+        conn = await asyncpg.connect(conn_url)
+    except Exception as e:
+        fail(f"SQL check: could not connect to Postgres: {e}")
+        return
+
+    try:
+        # Check points_log has rows
+        count = await conn.fetchval("SELECT COUNT(*) FROM points_log")
+        if count == 0:
+            fail("SQL: points_log is empty (expected completion rows)")
+        else:
+            ok(f"SQL: points_log has {count} rows")
+
+        # Check chore_log has rows for all expected action types
+        for action in ("completed", "skipped", "reassigned", "updated"):
+            action_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM chore_log WHERE action = $1", action
+            )
+            if action_count == 0:
+                fail(f"SQL: chore_log has no rows with action='{action}'")
+            else:
+                ok(f"SQL: chore_log action='{action}' has {action_count} rows")
+
+        # FK integrity: all chore_log.chore_id must reference a valid chore
+        orphans = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM chore_log cl
+            WHERE cl.chore_id NOT IN (SELECT id FROM chores)
+            """
+        )
+        if orphans > 0:
+            fail(f"SQL: {orphans} chore_log rows reference non-existent chore_id (FK violation)")
+        else:
+            ok("SQL: chore_log FK integrity OK (no orphaned chore_id references)")
+
+        # FK integrity: all points_log.chore_id must reference a valid chore
+        pl_orphans = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM points_log pl
+            WHERE pl.chore_id NOT IN (SELECT id FROM chores)
+            """
+        )
+        if pl_orphans > 0:
+            fail(f"SQL: {pl_orphans} points_log rows reference non-existent chore_id (FK violation)")
+        else:
+            ok("SQL: points_log FK integrity OK (no orphaned chore_id references)")
+
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def validate(base_url: str = BASE) -> None:
+    print(f"Running upgrade validation against {base_url}\n")
+
+    # Authenticate first
+    async with httpx.AsyncClient(base_url=base_url, timeout=30) as c:
+        login_r = await c.post("/auth/login", json={"username": "admin", "password": "adminpass123"})
+        if login_r.status_code != 200:
+            fail(f"Login failed: {login_r.status_code} {login_r.text}")
+            _report_results()
+            return
+
+        token = login_r.json()["access_token"]
+        c.headers.update({"Authorization": f"Bearer {token}"})
+
+        await check_health(c)
+        await check_people(c)
+        await check_chores(c)
+        await check_points(c)
+        await check_activity_log(c)
+
+    await check_sql_integrity()
+    _report_results()
+
+
+def _report_results() -> None:
+    print()
+    if FAILURES:
+        print(f"VALIDATION FAILED: {len(FAILURES)} check(s) failed:", file=sys.stderr)
+        for f in FAILURES:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("VALIDATION PASSED: all checks OK")
+
+
+if __name__ == "__main__":
+    base_url = BASE
+    args = sys.argv[1:]
+    if "--base-url" in args:
+        idx = args.index("--base-url")
+        base_url = args[idx + 1]
+    asyncio.run(validate(base_url))

--- a/docker-compose.test-upgrade.yml
+++ b/docker-compose.test-upgrade.yml
@@ -1,0 +1,89 @@
+# Upgrade regression test orchestration.
+#
+# Validates that data seeded against the previous release migrates correctly
+# when the new backend starts against the same Postgres volume.
+#
+# Usage (CI resolves PREV_TAG dynamically; local example shown below):
+#
+#   export PREV_TAG=v1.6.0
+#   docker compose -f docker-compose.test-upgrade.yml up --build --abort-on-container-exit
+#
+# Services:
+#   db         — Postgres (volume kept between old and new backend starts)
+#   old-backend — Previous release backend image (seeds data)
+#   seed       — Runs seed.py against the old backend
+#   new-backend — Current branch backend image (applies migrations)
+#   validate   — Runs validate_upgrade.py against the new backend
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: chores
+      POSTGRES_USER: chores
+      POSTGRES_PASSWORD: chores
+    volumes:
+      - upgrade-test-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chores"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  old-backend:
+    image: ghcr.io/derekwinters/chores-web/backend:${PREV_TAG}
+    environment:
+      DATABASE_URL: postgresql+asyncpg://chores:chores@db/chores
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  seed:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: python seed.py --base-url http://old-backend:8000
+    environment:
+      DATABASE_URL: postgresql+asyncpg://chores:chores@db/chores
+    depends_on:
+      old-backend:
+        condition: service_healthy
+    restart: "no"
+
+  new-backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://chores:chores@db/chores
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    restart: "no"
+
+  validate:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: python validate_upgrade.py --base-url http://new-backend:8000
+    environment:
+      DATABASE_URL: postgresql+asyncpg://chores:chores@db/chores
+    depends_on:
+      new-backend:
+        condition: service_healthy
+    restart: "no"
+
+volumes:
+  upgrade-test-postgres:

--- a/docker-compose.test-upgrade.yml
+++ b/docker-compose.test-upgrade.yml
@@ -38,7 +38,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20
@@ -66,7 +66,7 @@ services:
       seed:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/docker-compose.test-upgrade.yml
+++ b/docker-compose.test-upgrade.yml
@@ -5,8 +5,8 @@
 #
 # Usage (CI resolves PREV_TAG dynamically; local example shown below):
 #
-#   export PREV_TAG=v1.6.0
-#   docker compose -f docker-compose.test-upgrade.yml up --build --abort-on-container-exit
+#   export PREV_TAG=1.6.0
+#   docker compose -f docker-compose.test-upgrade.yml up --build -d && docker compose -f docker-compose.test-upgrade.yml wait validate
 #
 # Services:
 #   db         — Postgres (volume kept between old and new backend starts)

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -165,10 +165,9 @@ The upgrade regression test validates that data seeded against a previous releas
 1. **Pull previous release**: The job resolves the latest published GHCR tag dynamically at runtime.
 2. **Start old backend + Postgres**: Brings up `docker-compose.test-upgrade.yml` with the previous release image.
 3. **Seed comprehensive data**: Runs `backend/seed.py` against the old backend — creates People, Chores, Completions, Skips, Reassignments, and Amendments.
-4. **Stop old backend**: Shuts down the old backend container; Postgres volume is preserved.
-5. **Start new backend**: Builds the backend image from the current branch and starts it against the same Postgres volume.
-6. **Validate**: Runs `backend/validate_upgrade.py` — API assertions (entity counts, assignees, points log, activity log, health) plus raw SQL FK/count integrity checks.
-7. **Result**: Non-zero exit on any failure fails the CI job.
+4. **Start new backend**: Builds the backend image from the current branch and starts it against the same Postgres volume after seeding completes.
+5. **Validate**: Runs `backend/validate_upgrade.py` — API assertions (entity counts, assignees, points log, activity log, health) plus raw SQL FK/count integrity checks.
+6. **Result**: Non-zero exit on any failure fails the CI job.
 
 ### Files
 
@@ -186,7 +185,10 @@ The upgrade regression test validates that data seeded against a previous releas
 PREV_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
 
 # Run the upgrade test
-PREV_TAG=$PREV_TAG docker compose -f docker-compose.test-upgrade.yml up --build --abort-on-container-exit
+PREV_TAG=$PREV_TAG docker compose -f docker-compose.test-upgrade.yml up \
+  --build \
+  --abort-on-container-exit \
+  --exit-code-from validate
 ```
 
 ### Failure Mode

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -156,6 +156,43 @@ Frontend tests: 205/205 passing ✓
 Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
 ```
 
+## Upgrade Regression Test
+
+The upgrade regression test validates that data seeded against a previous release migrates correctly when the new backend starts against the same Postgres volume. It runs as a CI job on every PR to `main`.
+
+### How It Works
+
+1. **Pull previous release**: The job resolves the latest published GHCR tag dynamically at runtime.
+2. **Start old backend + Postgres**: Brings up `docker-compose.test-upgrade.yml` with the previous release image.
+3. **Seed comprehensive data**: Runs `backend/seed.py` against the old backend — creates People, Chores, Completions, Skips, Reassignments, and Amendments.
+4. **Stop old backend**: Shuts down the old backend container; Postgres volume is preserved.
+5. **Start new backend**: Builds the backend image from the current branch and starts it against the same Postgres volume.
+6. **Validate**: Runs `backend/validate_upgrade.py` — API assertions (entity counts, assignees, points log, activity log, health) plus raw SQL FK/count integrity checks.
+7. **Result**: Non-zero exit on any failure fails the CI job.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.test-upgrade.yml` | Upgrade test orchestration: Postgres + old backend + new backend services |
+| `backend/seed.py` | Comprehensive seeding: auth login + People, Chores, Completions, Skips, Reassignments, Amendments |
+| `backend/validate_upgrade.py` | Validation script: API assertions + raw SQL FK/count checks |
+| `.github/workflows/test.yml` | CI: `upgrade-regression` job added, triggered on PRs to `main` |
+
+### Running Locally
+
+```bash
+# Resolve the latest GHCR tag
+PREV_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+
+# Run the upgrade test
+PREV_TAG=$PREV_TAG docker compose -f docker-compose.test-upgrade.yml up --build --abort-on-container-exit
+```
+
+### Failure Mode
+
+The job exits non-zero and fails CI. Check the `validate` service logs for specific assertion failures.
+
 ## Observability
 
 ### Metrics Endpoint


### PR DESCRIPTION
## Summary

- Add `docker-compose.test-upgrade.yml` to orchestrate upgrade regression testing: Postgres + old backend + seed + new backend + validate services
- Update `backend/seed.py` with login step and comprehensive seeding of all entity/action types (Completions, Skips, Reassignments, Amendments)
- Add `backend/validate_upgrade.py` with API assertions (health, people, chores, points, activity log) and raw SQL FK/count integrity checks
- Add `upgrade-regression` CI job to `.github/workflows/test.yml` — resolves latest GHCR tag dynamically, runs on PRs to `main`
- Add `backend/tests/test_seed.py` with realistic seeded data to catch identifier mismatch bugs
- Add "Upgrade Regression Test" section to `docs/DEVELOPER.md`

## Issue

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)