### PR TITLE
feat: add release notes enforcement and blog infrastructure (#203)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,28 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  release-notes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Check for release notes on release PRs
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if echo "$PR_TITLE" | grep -qE '^chore\(main\): release v'; then
+            VERSION=$(echo "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+            RELEASE_FILE="docs/blog/posts/release-${VERSION}.md"
+            if [ ! -f "$RELEASE_FILE" ]; then
+              echo "Release PR detected for ${VERSION} but release notes file is missing: ${RELEASE_FILE}"
+              echo "Please create ${RELEASE_FILE} before merging this release PR."
+              exit 1
+            else
+              echo "Release notes found: ${RELEASE_FILE}"
+            fi
+          else
+            echo "Non-release PR — skipping release notes check."
+          fi
+
   upgrade-regression:
     runs-on: ubuntu-latest
     needs: [frontend-tests, backend-tests]

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -195,6 +195,41 @@ PREV_TAG=$PREV_TAG docker compose -f docker-compose.test-upgrade.yml up \
 
 The job exits non-zero and fails CI. Check the `validate` service logs for specific assertion failures.
 
+## Release Notes
+
+Release notes live in the MkDocs blog at `docs/blog/posts/`. Each release requires a corresponding blog post before the release PR can merge.
+
+### File Naming
+
+Release notes files must follow this naming convention:
+
+```
+docs/blog/posts/release-v{VERSION}.md
+```
+
+For example, for version `1.7.0`: `docs/blog/posts/release-v1.7.0.md`.
+
+### CI Enforcement
+
+The `release-notes` CI job in `.github/workflows/test.yml` runs on every pull request. It detects release PRs by title pattern `chore(main): release v*` and fails if the corresponding release notes file is missing. Non-release PRs skip the check automatically.
+
+### Creating Release Notes
+
+Create the blog post file before or alongside the release PR:
+
+```bash
+# For version v1.7.0
+cat > docs/blog/posts/release-v1.7.0.md << 'EOF'
+---
+date: 2026-01-01
+---
+
+# Release v1.7.0
+
+Summary of changes in this release.
+EOF
+```
+
 ## Observability
 
 ### Metrics Endpoint

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,3 @@
+# Blog
+
+Release notes and project updates for Chores.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Chores Documentation
 site_description: REST API for managing household chores and tracking
-repo_url: https://github.com/yourusername/chores-web
+repo_url: https://github.com/derekwinters/chores-web
 repo_name: chores-web
 edit_uri: edit/main/docs/
 
@@ -45,7 +45,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       provider: github
-      user: yourusername
+      user: derekwinters
       repo: chores-web
   - pymdownx.mark
   - pymdownx.superfences:
@@ -65,6 +65,9 @@ markdown_extensions:
 plugins:
   - search:
       lang: en
+  - blog:
+      blog_dir: blog
+      post_url_format: "{slug}"
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -76,6 +79,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Blog: blog/index.md
   - User Guide: USER_GUIDE.md
   - API Reference:
     - Overview & Auth: api/index.md
@@ -94,7 +98,7 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/yourusername/chores-web
+      link: https://github.com/derekwinters/chores-web
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com
 


### PR DESCRIPTION
## Summary

- Fix `yourusername` placeholders in `mkdocs.yml` (repo_url, magiclink plugin, social links) → `derekwinters`
- Add MkDocs Material `blog` plugin to `mkdocs.yml` with `blog_dir: blog` and slug-based post URLs
- Create `docs/blog/index.md` and `docs/blog/posts/` directory for release notes
- Add Blog nav entry after Home in `mkdocs.yml` nav
- Add `release-notes` CI job to `test.yml`: detects release PRs by title pattern `chore(main): release v*`, fails if `docs/blog/posts/release-v{VERSION}.md` is missing, skips for non-release PRs
- Add Release Notes section to `DEVELOPER.md` documenting file naming, CI enforcement, and creation workflow

## Issue

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)