### PR TITLE
docs: add release notes blog posts v1.0.0–v1.7.0 (#279)

### DIFF
--- a/docs/blog/posts/2026-04-26-release-v1-0-0.md
+++ b/docs/blog/posts/2026-04-26-release-v1-0-0.md
@@ -19,7 +19,6 @@ The first stable release of Chores — a household chore tracking app with user 
 - Multi-column layout on the chores list page
 - Sort chores by next due date
 - Chore assignee can be edited inline
-- Open chores unassign automatically after completion
 - Reset chore state when `next_due` is updated
 
 ### Filtering & Navigation

--- a/docs/blog/posts/2026-04-26-release-v1-0-0.md
+++ b/docs/blog/posts/2026-04-26-release-v1-0-0.md
@@ -1,0 +1,69 @@
+---
+date: 2026-04-26
+categories:
+  - Release Notes
+---
+
+# Release v1.0.0
+
+The first stable release of Chores — a household chore tracking app with user assignments, points, and a full REST API. This release establishes the core feature set built up over the initial development sprint.
+
+<!-- more -->
+
+## Features
+
+### Chore Management
+
+- Complete and skip buttons on chore cards with activity logging
+- Collapse/expand chore cards via left accent bar for a cleaner list view
+- Multi-column layout on the chores list page
+- Sort chores by next due date
+- Chore assignee can be edited inline
+- Open chores unassign automatically after completion
+- Reset chore state when `next_due` is updated
+
+### Filtering & Navigation
+
+- Age-based chore filter; automatic assignee filtering removed
+- Assignee filter upgraded to multi-select dropdown
+- URL query parameter sync for chore filters — bookmarkable views
+- URL query parameter filtering on `/logs`
+- Dashboard due-soon counts include both assigned and unassigned chores
+- Dashboard due-soon links navigate to pre-filtered chore views
+- Default chores page opens in user-focused view
+
+### Users & History
+
+- Responsive column layout on users page with separate admin/member sections
+- User detail page with filtered activity history
+- History links on chore and user cards
+- Profile and Settings options in avatar menu
+
+### Points & Admin
+
+- Points field added to Person model with admin update API
+- Import/export UI for full data management
+
+### App Configuration
+
+- Configurable app-wide timezone setting
+
+### Assignment Validation
+
+- Assignment validation function added
+- Validation integrated into chore create/update endpoints
+
+### Developer Tooling
+
+- Skills system added; existing commands migrated to skills
+
+## Bug Fixes
+
+- Unassigning chores now works correctly — explicit `null` values preserved
+- `daysFromNow` filter applied to Due Soon link; Manage renamed to Chores
+- Chore form default points set to 1 instead of 0
+- Calendar dialog replaced with themed Material-UI DatePicker
+- Sign-in page: autocapitalization disabled, page no longer reloads on error
+- Theme persists correctly across page reload
+- Sidebar uses dynamic viewport height on tablets
+- Avatar menu dropdown z-index fixed — no longer hidden behind chore cards

--- a/docs/blog/posts/2026-04-26-release-v1-1-0.md
+++ b/docs/blog/posts/2026-04-26-release-v1-1-0.md
@@ -1,0 +1,19 @@
+---
+date: 2026-04-26
+categories:
+  - Release Notes
+---
+
+# Release v1.1.0
+
+v1.1.0 adds a points redemption system — admins can redeem points for users, and redemption history is tracked per user.
+
+<!-- more -->
+
+## Features
+
+### Points & Redemption
+
+- Admin UI for redeeming points on behalf of users
+- Total points tracking with redemption deducted from running balance
+- Redemption history displayed on user detail page

--- a/docs/blog/posts/2026-05-08-release-v1-2-0.md
+++ b/docs/blog/posts/2026-05-08-release-v1-2-0.md
@@ -1,0 +1,37 @@
+---
+date: 2026-05-08
+categories:
+  - Release Notes
+---
+
+# Release v1.2.0
+
+v1.2.0 introduces database migration infrastructure, a configurable due-soon threshold, better startup UX, and a new AI-assisted implementation workflow.
+
+<!-- more -->
+
+## Features
+
+### Database & Migrations
+
+- Alembic migrations set up for schema management
+- Database status tracking with `/db-status` endpoint
+- "Update In Progress" UI shown during database startup and migrations
+
+### Chore Filtering
+
+- Configurable due-soon threshold — adjust how far ahead "due soon" looks
+
+### Developer & AI Tooling
+
+- `github-issue-categorize` skill added
+- `github-issue-implementation-orchestrator` agent added
+- `github-issue-plan-orchestrator` agent added
+
+## Bug Fixes
+
+- Database sequences initialized to prevent primary key constraint violations on fresh installs
+- Documentation validation added as a PR check
+- gh-pages deployment corrected to handle history conflicts
+- Documentation build failures resolved
+- Missing Docker push permissions for ghcr.io added

--- a/docs/blog/posts/2026-05-10-release-v1-3-0.md
+++ b/docs/blog/posts/2026-05-10-release-v1-3-0.md
@@ -1,0 +1,43 @@
+---
+date: 2026-05-10
+categories:
+  - Release Notes
+---
+
+# Release v1.3.0
+
+v1.3.0 brings a major admin panel overhaul, expanded activity logging, an update checker, and mobile layout improvements.
+
+<!-- more -->
+
+## Features
+
+### Admin Panel
+
+- Admin panel reorganized into separate pages by section
+- Database management dashboard for PointsLog added
+
+### Activity Logging
+
+- User goal value changes now logged
+- Unlogged chore modifications now captured
+- Separate actor and content columns in chore change logs — who changed what is clearly distinguished
+- Actual user logged when skipping chores instead of system
+
+### Log View
+
+- Log entries are clickable — expand inline as a detail row
+- Reduced columns on mobile to prevent horizontal scrolling
+
+### Update Checker
+
+- Periodic update checker with GitHub API integration — app notifies when a new version is available
+
+## Bug Fixes
+
+- Boolean config values normalized in storage and export
+- Settings values populated on Admin Panel load
+- Database sequences resynced; initial Alembic revision stamped on `DuplicateTable` error
+- Actor logging standardized to usernames; `schedule` and `system` actors distinguished
+- Points window filtering and dashboard lookup key corrected
+- Mobile: keep points and due grids at 2 columns

--- a/docs/blog/posts/2026-05-16-release-v1-4-0.md
+++ b/docs/blog/posts/2026-05-16-release-v1-4-0.md
@@ -1,0 +1,48 @@
+---
+date: 2026-05-16
+categories:
+  - Release Notes
+---
+
+# Release v1.4.0
+
+v1.4.0 is the largest release since v1.0.0, delivering a complete theme system overhaul, chore summary stats, UI polish across the board, and the grilling-based AI planning workflow.
+
+<!-- more -->
+
+## Features
+
+### Theme System
+
+- Unified 9-color theme structure defined — all UI components use CSS custom properties
+- Hex color input and color picker added to theme editor
+- Theme list UX improved with action icons and color preview swatches
+- Personal theme selection separated from the default theme setting
+- Paper default with borderless cards and consistent shadows
+
+### Chores Page
+
+- Summary stats tiles added to the `/chores` page — at-a-glance counts for due, overdue, and upcoming
+- Open chores unassign automatically after completion
+
+### Log View
+
+- Relative timestamps and redesigned badges for a cleaner activity log
+
+### UI Polish
+
+- Save button feedback added for all save actions — no more wondering if it worked
+- Error messages improved with fallback strategy
+
+### AI Tooling
+
+- `grill-me` skill and doc-aware planning/implementation workflow added
+
+## Bug Fixes
+
+- Chore assignee filter corrected to respect `eligible_people`
+- Expanded chore card retains highlight color on open
+- Adjacent column cards no longer stretch vertically when a card expands
+- Preferences removed from sidebar navigation
+- Theme calendar colors fixed for light themes
+- Pink theme saturation reduced to accent/highlight use only

--- a/docs/blog/posts/2026-05-17-release-v1-5-0.md
+++ b/docs/blog/posts/2026-05-17-release-v1-5-0.md
@@ -1,0 +1,21 @@
+---
+date: 2026-05-17
+categories:
+  - Release Notes
+---
+
+# Release v1.5.0
+
+v1.5.0 adds chore status filtering and fixes the Due Soon display to only show upcoming chores.
+
+<!-- more -->
+
+## Features
+
+### Chore Filtering
+
+- Chore status filtering added — filter by open, completed, or skipped
+
+## Bug Fixes
+
+- Due Soon now correctly shows only upcoming chores, not already-completed ones

--- a/docs/blog/posts/2026-05-18-release-v1-6-0.md
+++ b/docs/blog/posts/2026-05-18-release-v1-6-0.md
@@ -1,0 +1,31 @@
+---
+date: 2026-05-18
+categories:
+  - Release Notes
+---
+
+# Release v1.6.0
+
+v1.6.0 improves the chores page layout and mobile experience, adds a completer prompt for unassigned chores, and refreshes the AI workflow tooling.
+
+<!-- more -->
+
+## Features
+
+### Chores Page Layout
+
+- Chores page layout redesigned for better use of screen space
+- Mobile chores page improved — tighter layout, better readability
+
+### Chore Completion
+
+- When completing an unassigned chore, a prompt asks who completed it — points go to the right person
+
+### AI Tooling
+
+- Agents and skills refreshed for the grilling-based implementation workflow
+
+## Bug Fixes
+
+- Manual update check now bypasses throttle and cache — always gets the current version
+- Points log edits correctly adjust person totals

--- a/docs/blog/posts/2026-05-25-release-v1-7-0.md
+++ b/docs/blog/posts/2026-05-25-release-v1-7-0.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-25
+categories:
+  - Release Notes
+---
+
+# Release v1.7.0
+
+v1.7.0 focuses on observability, testing infrastructure, release process tooling, and documentation reorganization.
+
+<!-- more -->
+
+## Features
+
+### Observability
+
+- Prometheus metrics endpoint added — expose app health and performance metrics to your monitoring stack (#202)
+
+### Testing Infrastructure
+
+- Upgrade regression test infrastructure added — catches regressions introduced by version upgrades (#207)
+- Realistic seeded test data added — covers identifier mismatch and display-layer bugs that sparse data misses (#211)
+
+### Release Process
+
+- Release notes enforcement and blog infrastructure established — this blog post is the first result (#203)
+
+### Documentation
+
+- Docs reorganized into focused sub-pages — architecture, deployment, developer guide, and user guide each split into dedicated sections (#281)


### PR DESCRIPTION
## Summary

- Add 8 blog posts in `docs/blog/posts/` covering every minor release from v1.0.0 through v1.7.0
- Each post: minimal frontmatter (`date` + `categories: [Release Notes]`), short intro, organized Features / Bug Fixes sections
- Patch releases (v1.5.1, v1.5.2) skipped — minor/major releases tell the story
- v1.0.0–v1.6.0 sourced from GitHub release data; v1.7.0 assembled from closed milestone PRs (#202, #203, #207, #211, #281)
- One commit per post

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)