### PR TITLE
feat(frontend): move choose file button to section-right (#217)

### DIFF
--- a/frontend/src/__tests__/ExportImport.test.jsx
+++ b/frontend/src/__tests__/ExportImport.test.jsx
@@ -194,6 +194,46 @@ describe("ExportImport", () => {
     });
   });
 
+  it("renders file-input-label in section-right, not section-left", () => {
+    const { container } = wrap(<ExportImport />);
+    const importSection = container.querySelector(".import-section");
+    const sectionLeft = importSection.querySelector(".section-left");
+    const sectionRight = importSection.querySelector(".section-right");
+
+    expect(sectionRight.querySelector(".file-input-label")).toBeInTheDocument();
+    expect(sectionLeft.querySelector(".file-input-label")).not.toBeInTheDocument();
+  });
+
+  it("Proceed with Import button is not inside section-body when importData is set", async () => {
+    const { container } = wrap(<ExportImport />);
+    const fileInput = document.querySelector('input[type="file"]');
+
+    const file = new File([JSON.stringify(mockExportData)], "backup.json", { type: "application/json" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      const sectionBody = container.querySelector(".import-section .section-body");
+      const proceedBtn = screen.getByText("Proceed with Import");
+      expect(sectionBody.contains(proceedBtn)).toBe(false);
+    });
+  });
+
+  it("Proceed with Import button renders below section-body when importData is set", async () => {
+    const { container } = wrap(<ExportImport />);
+    const fileInput = document.querySelector('input[type="file"]');
+
+    const file = new File([JSON.stringify(mockExportData)], "backup.json", { type: "application/json" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      const importSection = container.querySelector(".import-section");
+      const sectionBody = importSection.querySelector(".section-body");
+      const proceedBtn = screen.getByText("Proceed with Import");
+      expect(sectionBody.contains(proceedBtn)).toBe(false);
+      expect(importSection.contains(proceedBtn)).toBe(true);
+    });
+  });
+
   it("can cancel import confirmation", async () => {
     wrap(<ExportImport />);
     const fileInput = document.querySelector('input[type="file"]');

--- a/frontend/src/components/ExportImport.jsx
+++ b/frontend/src/components/ExportImport.jsx
@@ -107,24 +107,28 @@ export default function ExportImport() {
       <div className="import-section">
         <h4>Import Data</h4>
         {!confirmImport ? (
-          <div className="section-body">
-            <div className="section-left">
-              <p className="section-description">Upload a backup file to restore data. This will replace all existing chores, people, and settings.</p>
-              <label htmlFor="import-file" className="file-input-label">
-                <input
-                  id="import-file"
-                  type="file"
-                  accept=".json"
-                  onChange={handleFileChange}
-                  disabled={importMutation.isPending}
-                />
-                <span className="file-input-button">
-                  {importFile ? `Selected: ${importFile.name}` : "Choose File"}
-                </span>
-              </label>
+          <>
+            <div className="section-body">
+              <div className="section-left">
+                <p className="section-description">Upload a backup file to restore data. This will replace all existing chores, people, and settings.</p>
+              </div>
+              <div className="section-right">
+                <label htmlFor="import-file" className="file-input-label">
+                  <input
+                    id="import-file"
+                    type="file"
+                    accept=".json"
+                    onChange={handleFileChange}
+                    disabled={importMutation.isPending}
+                  />
+                  <span className="file-input-button">
+                    {importFile ? `Selected: ${importFile.name}` : "Choose File"}
+                  </span>
+                </label>
+              </div>
             </div>
-            <div className="section-right">
-              {importData && (
+            {importData && (
+              <div className="confirm-actions">
                 <button
                   className="btn-primary export-import-btn"
                   onClick={() => setConfirmImport(true)}
@@ -132,9 +136,9 @@ export default function ExportImport() {
                 >
                   Proceed with Import
                 </button>
-              )}
-            </div>
-          </div>
+              </div>
+            )}
+          </>
         ) : (
           <div className="import-confirm">
             <div className="confirm-warning">


### PR DESCRIPTION
## Summary
- Move `file-input-label` (Choose File button) from `section-left` to `section-right` in the Import section, mirroring the Export section layout
- Remove Proceed with Import button from inside `section-body`'s conditional `section-right` wrapper
- Render Proceed with Import button below `section-body`, right-aligned via `confirm-actions` wrapper, when a file has been parsed
- No new CSS classes required

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)