### PR TITLE
feat: add milestone implementation orchestrator (#296)

### DIFF
--- a/.claude/agents/milestone-implementation-orchestrator.md
+++ b/.claude/agents/milestone-implementation-orchestrator.md
@@ -1,0 +1,217 @@
+---
+name: milestone-implementation-orchestrator
+description: Automated workflow coordinator for implementing all issues in a GitHub milestone end-to-end on a single shared branch and PR
+type: agent
+---
+
+# Milestone Implementation Orchestrator Agent
+
+Implements all issues in a GitHub milestone sequentially on a shared branch, culminating in a single PR suitable for Release-Please.
+
+## Invocation
+
+```
+@milestone-implementation-orchestrator https://github.com/derekwinters/chores-web/milestone/N
+```
+
+## IMPORTANT: Display Workflow Diagram on Every State Transition
+
+Display the workflow diagram each time you transition to a new state, immediately before executing that state's work. Highlight the destination state with heavy borders (┃, ┏┓┗┛).
+
+## State Machine
+
+```
+START
+  ↓
+[1] parse-milestone
+  ├─ Extract milestone number from URL
+  ├─ gh api fetch milestone title and issue list
+  ├─ Extract version string from title (e.g. "v1.9.0" → "1.9.0")
+  └─ Result: milestone_number, milestone_title, version, issue_list
+          ↓
+[2] bulk-validate
+  ├─ For each milestone issue: check ready-for-work label + grilling comment + OPEN state
+  ├─ Show table of all issues with pass/fail status
+  ├─ ABORT if ANY issue fails validation
+  └─ Result: validated issue list
+          ↓
+[3] dependency-order
+  ├─ Read all issue titles and grilling comment bodies
+  ├─ AI-reason over content to determine safe implementation order
+  ├─ Output ordered list with one-line rationale per issue
+  └─ Result: implementation_order[]
+          ↓
+[4] branch-setup
+  ├─ git fetch origin && git checkout main && git pull origin main
+  ├─ git checkout -b feat/milestone-<version>
+  └─ Result: branch feat/milestone-<version> ready
+          ↓
+[5] release-commit
+  ├─ git commit --allow-empty -m "chore: release <version>" with trailer "Release-As: <version>"
+  └─ Result: Release-Please anchor commit on branch
+          ↓
+[6] draft-pr
+  ├─ git push -u origin feat/milestone-<version>
+  ├─ gh pr create --draft --title "feat: Milestone <version>"
+  ├─ Body: ## Milestone <version>\n\n[issue list with titles]\n\n(Closes #N lines appended per-issue during implementation)
+  └─ Result: pr_url, pr_number
+          ↓
+[7] implement-issues (loop over implementation_order)
+  ├─ For each issue:
+  │   ├─ Invoke github-issue-implementation-orchestrator with:
+  │   │   - existing_branch=feat/milestone-<version>
+  │   │   - existing_pr=<pr_number>
+  │   ├─ Wait for issue orchestrator to complete (do NOT proceed until done)
+  │   ├─ On failure: HALT immediately → report failed issue + branch/PR state
+  │   └─ On success: gh issue edit <N> --remove-label in-development
+  └─ Result: all issues implemented
+          ↓
+[8] finalize
+  ├─ gh pr ready <pr_number>
+  └─ Result: PR marked ready for review
+          ↓
+[9] complete
+  ├─ Display PR URL
+  ├─ Info: All milestone issues auto-close when PR merges
+  └─ END
+```
+
+## Output Format
+
+```
+MILESTONE IMPLEMENTATION WORKFLOW
+==================================
+
+┌────────────────┐  ┌───────────────┐  ┌──────────────┐  ┌──────────────┐  ┌─────────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+│ Parse Milestone├─▶│ Bulk Validate ├─▶│  Dep. Order  ├─▶│ Branch Setup ├─▶│ Rel. Commit ├─▶│ Draft PR ├─▶│Impl Loop ├─▶│ Finalize ├─▶│ Complete │
+└────────────────┘  └───────────────┘  └──────────────┘  └──────────────┘  └─────────────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘
+```
+
+Also display milestone context at each state:
+
+```
+Milestone: v1.9.0 (#7)
+State: [7] Implement Issues
+Progress: 7/9
+Branch: feat/milestone-1.9.0
+Issues: 3/8 complete
+Current: #301 Add user notifications
+```
+
+## Version Extraction
+
+From milestone title, extract semver string:
+- "v1.9.0" → "1.9.0"
+- "Release 2.0.0" → "2.0.0"
+- "Milestone 1.8.0" → "1.8.0"
+- "1.8.0" → "1.8.0"
+
+## Bulk Validation Rules
+
+Each milestone issue must have ALL of:
+1. State: OPEN
+2. Label: `ready-for-work`
+3. A grilling comment: any comment body containing `## Grilling Session`
+
+Display results as table:
+
+| Issue | Title | OPEN | ready-for-work | Grilling | Status |
+|-------|-------|------|----------------|----------|--------|
+| #301  | ...   | ✅   | ✅             | ✅       | PASS   |
+| #302  | ...   | ✅   | ❌             | ✅       | FAIL   |
+
+ABORT if any FAIL. Message: "Fix failing issues, then re-run."
+
+## Dependency Ordering
+
+For each issue, read:
+- Issue title
+- Grilling comment "Impact Areas" table
+- Grilling comment "Behaviors to Implement" list
+
+Reason about ordering:
+- Database schema changes before code that queries them
+- Backend API changes before frontend that calls them
+- Shared utility/infrastructure before features that use them
+- Independent issues ordered arbitrarily (by issue number)
+
+Output:
+```
+Implementation order:
+1. #301 Add user schema field — database change, must precede API update
+2. #303 Update people API — depends on #301 schema
+3. #302 Frontend notifications — depends on #303 API
+```
+
+## Release-Please Commit
+
+```bash
+git commit --allow-empty -m "$(cat <<'EOF'
+chore: release <version>
+
+Release-As: <version>
+EOF
+)"
+```
+
+This empty commit signals Release-Please to cut a release at `<version>` when the PR merges.
+
+## Milestone-Mode Context for Issue Orchestrator
+
+Pass to each `github-issue-implementation-orchestrator` invocation:
+- `existing_branch=feat/milestone-<version>` — skips branch creation, checks out shared branch
+- `existing_pr=<pr_number>` — skips push+PR creation, appends summary + `Closes #N` to existing PR body
+
+The issue orchestrator's `in-development` label removal at finalize is SKIPPED in milestone mode — this orchestrator removes it after each issue completes.
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Milestone URL not found | ABORT |
+| Milestone has no issues | ABORT |
+| Any issue fails bulk-validate | ABORT — list failing issues |
+| Branch already exists | ABORT — re-run safety; delete branch to restart |
+| Issue orchestrator fails | HALT — report failed issue, branch, PR URL for manual intervention |
+| Push fails | PAUSE — investigate, report |
+
+On issue orchestrator failure, report:
+```
+HALT: Issue #<N> failed during implementation.
+Branch: feat/milestone-<version>
+PR: <pr_url>
+Completed issues: #X, #Y, #Z
+Remaining issues: #A, #B
+Manual steps: resolve issue on branch, then re-invoke from #<N>
+```
+
+## Notes
+
+- Fully autonomous — no per-issue user review pauses within the milestone loop
+- Single shared branch + PR for entire milestone
+- Each issue gets its own conventional commit(s) via the issue orchestrator
+- PR auto-closes all milestone issues when merged (Closes #N appended per-issue)
+- `in-development` label removed per-issue by this orchestrator after each issue completes
+- Release-Please reads the empty anchor commit to determine release version
+- Safe to re-run from clean state; branch-already-exists check prevents duplicate work
+
+## Related Agents & Skills
+
+### Agents
+- **github-issue-implementation-orchestrator**: Implements individual issues; invoked per-issue with milestone-mode params
+
+### Skills Called (in order)
+1. *(parse-milestone)* — agent reads GitHub API directly via `gh`
+2. *(bulk-validate)* — agent calls `gh` for each issue
+3. *(dependency-order)* — agent reasons over issue content
+4. *(branch-setup)* — agent runs git commands directly
+5. *(release-commit)* — agent runs git commit --allow-empty
+6. *(draft-pr)* — agent runs gh pr create --draft
+7. **github-issue-implementation-orchestrator** × N — one per issue, with existing_branch + existing_pr
+8. *(finalize)* — agent runs gh pr ready
+
+## Workflow Chain
+
+1. `github-issue-triage-orchestrator` → labels each issue as `ready-to-grill`
+2. `/grill-with-docs issue <N>` × N → labels each as `ready-for-work`
+3. `milestone-implementation-orchestrator` → implements all, creates single milestone PR

--- a/.claude/skills/implementation-finalize/prompt.txt
+++ b/.claude/skills/implementation-finalize/prompt.txt
@@ -1,14 +1,17 @@
 Commit changes and create pull request.
 
 Inputs: issue_number, commit_type
+Optional: existing_pr
 
 Steps:
+
+## When existing_pr is NOT provided (default):
 1. Stage all changes: git add -A
 2. Create conventional commit:
    - Subject: <type>: <description> (#<number>)
    - Example: feat: Add flexible skip options for chores (#129)
    - Body: Explain why, decisions made, important context
-   - Footer: Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+   - Footer: Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 3. Commit: git commit -m "..."
 4. Push branch: git push -u origin <branch>
 5. Create PR:
@@ -34,8 +37,29 @@ Success output:
 - Branch: feat-issue-129
 - PR URL: https://github.com/derekwinters/chores-web/pull/168
 
+## When existing_pr IS provided (milestone mode):
+1. Stage all changes: git add -A
+2. Create conventional commit (same format as above)
+3. Commit: git commit -m "..."
+4. Push to existing branch: git push
+5. Append per-issue summary block to existing PR body:
+   a. Fetch current PR body: gh pr view <existing_pr> --json body -q .body
+   b. Append block:
+      ### Issue #<issue_number>: <issue_title>
+      - Commit: <commit_subject>
+
+      Closes #<issue_number>
+   c. Update PR: gh pr edit <existing_pr> --body "<updated_body>"
+6. Return PR URL
+
+Success output (milestone mode):
+✅ Issue committed and PR updated
+- Commit: feat: Add flexible skip options for chores (#129)
+- Branch: feat/milestone-1.9.0 (shared)
+- PR URL: https://github.com/derekwinters/chores-web/pull/168 (updated)
+
 Failure cases:
 - Staging fails: Report git error
 - Commit fails: Report message/format error
 - Push fails: Report network/permission error
-- PR creation fails: Report API error
+- PR creation/update fails: Report API error

--- a/.claude/skills/implementation-prepare/prompt.txt
+++ b/.claude/skills/implementation-prepare/prompt.txt
@@ -1,8 +1,11 @@
 Prepare git branch for issue implementation.
 
 Inputs: issue_number, commit_type
+Optional: existing_branch
 
 Steps:
+
+## When existing_branch is NOT provided (default):
 1. Fetch and update main: git fetch origin && git checkout main && git pull origin main
 2. Create feature branch: git checkout -b <type>-issue-<number>
    Example: git checkout -b feat-issue-129
@@ -12,7 +15,16 @@ Steps:
    - Status: Ready for implementation
    - Next: Begin implementation per issue requirements
 
+## When existing_branch IS provided (milestone mode):
+1. Fetch and update branch: git fetch origin && git checkout <existing_branch> && git pull origin <existing_branch>
+2. Verify branch is active: git branch --show-current
+3. Report success:
+   - Branch name: <existing_branch> (existing)
+   - Status: Ready for implementation (milestone mode — branch shared)
+   - Next: Begin implementation per issue requirements
+
 Error cases:
-- Branch already exists locally: Suggest using existing branch
+- Branch already exists locally (default mode): Suggest using existing branch
+- existing_branch not found: Report branch does not exist
 - Git fetch/pull fails: Report network or permission issue
 - Branch creation fails: Report git error


### PR DESCRIPTION
## Summary

- Add `milestone-implementation-orchestrator` agent: implements all issues in a GitHub milestone on a single shared branch with a Release-Please-compatible PR
- Add `existing_branch` optional param to `implementation-prepare` skill: skips branch creation and checks out named branch instead (milestone mode)
- Add `existing_pr` optional param to `implementation-finalize` skill: skips push+PR creation and appends per-issue summary + `Closes #N` to existing PR body (milestone mode)

## Implementation

- Agent: 9-state machine — parse milestone URL → bulk-validate all issues → AI dependency ordering → branch setup → Release-Please anchor commit → draft PR → per-issue implementation loop → finalize
- All issues validated upfront (ready-for-work + grilling comment) before any code is touched
- Failure halts immediately, preserving partial progress on shared branch for manual intervention
- `in-development` label removed per-issue by milestone orchestrator, not issue orchestrator

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)