### PR TITLE
feat: improve auth log page UX with Log component patterns (#300)

### DIFF
--- a/frontend/src/__tests__/SettingsAuth.test.jsx
+++ b/frontend/src/__tests__/SettingsAuth.test.jsx
@@ -52,6 +52,22 @@ describe("SettingsAuth", () => {
     });
   });
 
+  it("renders the Auth page heading", async () => {
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 2, name: "Auth" })).toBeInTheDocument();
+    });
+  });
+
+  it("renders an Auth Event Log link after the Authentication section", async () => {
+    wrap();
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /auth event log/i })).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: /auth event log/i });
+    expect(link).toHaveAttribute("href", "/settings/auth/log");
+  });
+
   it("renders the Authentication section heading", async () => {
     wrap();
     await waitFor(() => {

--- a/frontend/src/__tests__/SettingsAuthLog.test.jsx
+++ b/frontend/src/__tests__/SettingsAuthLog.test.jsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route, Outlet } from "react-router-dom";
+import SettingsAuthLog from "../pages/SettingsAuthLog";
+import * as client from "../api/client";
+
+vi.mock("../api/client");
+vi.mock("../contexts/AuthContext", () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => ({ user: { username: "admin", is_admin: true }, logout: vi.fn() }),
+}));
+
+const AUTH_ENTRIES = Array.from({ length: 25 }, (_, i) => ({
+  id: i + 1,
+  username: i % 2 === 0 ? "alice" : "bob",
+  action: i % 3 === 0 ? "login_succeeded" : i % 3 === 1 ? "login_failed" : "password_changed",
+  changed_by: i % 2 === 0 ? null : "admin",
+  timestamp: new Date(2026, 0, i + 1).toISOString(),
+}));
+
+function wrap({ initialEntries = ["/settings/auth/log"] } = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/settings/auth/log" element={<SettingsAuthLog />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("SettingsAuthLog", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    client.getAuthLog.mockResolvedValue(AUTH_ENTRIES);
+  });
+
+  // Behavior 3: root wrapper uses log class, imports Log.css
+  it("renders root div with class 'log'", async () => {
+    const { container } = wrap();
+    await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+    expect(container.firstChild).toHaveClass("log");
+  });
+
+  // Behavior 4: page-header with h2 and filter toggle button
+  it("renders page-header with h2 'Auth Event Log'", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 2, name: /auth event log/i })).toBeInTheDocument()
+    );
+  });
+
+  it("renders filter toggle button in page-header", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /show filters|hide filters/i })).toBeInTheDocument()
+    );
+  });
+
+  // Behavior 5: collapsible log-filters panel
+  it("filter panel is hidden by default", async () => {
+    const { container } = wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 2, name: /auth event log/i })).toBeInTheDocument()
+    );
+    expect(container.querySelector(".log-filters")).not.toBeInTheDocument();
+  });
+
+  it("clicking filter toggle shows filter panel with filter-group elements", async () => {
+    const { container } = wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /show filters/i })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    await waitFor(() =>
+      expect(container.querySelector(".log-filters")).toBeInTheDocument()
+    );
+    expect(container.querySelectorAll(".filter-group").length).toBeGreaterThan(0);
+  });
+
+  it("clicking filter toggle again hides filter panel", async () => {
+    const { container } = wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /show filters/i })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    await waitFor(() =>
+      expect(container.querySelector(".log-filters")).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /hide filters/i }));
+    await waitFor(() =>
+      expect(container.querySelector(".log-filters")).not.toBeInTheDocument()
+    );
+  });
+
+  // Behavior 6: log-table CSS class
+  it("renders table with log-table class", async () => {
+    const { container } = wrap();
+    await waitFor(() =>
+      expect(container.querySelector("table.log-table")).toBeInTheDocument()
+    );
+  });
+
+  // Behavior 7: URL search params for filter state
+  it("filter state survives navigation (URL search params)", async () => {
+    const { container } = wrap({ initialEntries: ["/settings/auth/log?action=login_failed"] });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /show filters/i })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /show filters/i }));
+    await waitFor(() => expect(container.querySelector(".log-filters")).toBeInTheDocument());
+    // action filter should be pre-selected from URL
+    const actionSelect = screen.getByLabelText(/filter by action/i);
+    expect(actionSelect.value).toBe("login_failed");
+  });
+
+  it("getAuthLog is called with filters from URL params", async () => {
+    wrap({ initialEntries: ["/settings/auth/log?username=alice&action=login_succeeded"] });
+    await waitFor(() => {
+      expect(client.getAuthLog).toHaveBeenCalledWith(
+        expect.objectContaining({ username: "alice", action: "login_succeeded" })
+      );
+    });
+  });
+
+  // Behavior 8: client-side pagination at 20 rows per page
+  it("shows only 20 rows on first page when more than 20 entries exist", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getAllByText("alice").length).toBeGreaterThan(0)
+    );
+    // 25 entries, page 1 shows 20
+    const rows = screen.getAllByRole("row");
+    // thead row + 20 data rows = 21
+    expect(rows.length).toBe(21);
+  });
+
+  it("renders log-pagination controls", async () => {
+    const { container } = wrap();
+    await waitFor(() =>
+      expect(container.querySelector(".log-pagination")).toBeInTheDocument()
+    );
+  });
+
+  it("Previous button is disabled on first page", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled()
+    );
+  });
+
+  it("Next button navigates to page 2", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      // 25 entries, page 2 shows 5 rows + 1 header
+      expect(rows.length).toBe(6);
+    });
+  });
+
+  it("Next button is disabled on last page", async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled()
+    );
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/pages/SettingsAuth.jsx
+++ b/frontend/src/pages/SettingsAuth.jsx
@@ -75,22 +75,8 @@ export default function SettingsAuth() {
 
   return (
     <div className="settings-page">
+      <h2>Auth</h2>
       {error && <div className="error-message">{error}</div>}
-
-      <section className="settings-section">
-        <div className="section-row">
-          <h3>Auth Event Log</h3>
-        </div>
-        <hr />
-        <div className="section-content">
-          <p className="setting-description">
-            View authentication events: logins, failed attempts, password changes, and user creation.
-          </p>
-          <Link to="/settings/auth/log" className="btn-secondary" style={{ display: "inline-block", marginTop: "0.25rem" }}>
-            View Auth Log
-          </Link>
-        </div>
-      </section>
 
       <section className="settings-section">
         <div className="section-row">
@@ -122,6 +108,16 @@ export default function SettingsAuth() {
                 : "App is accessible without authentication"}
             </p>
           </div>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-row">
+          <h3>Auth Event Log</h3>
+        </div>
+        <hr />
+        <div className="section-content">
+          <Link to="/settings/auth/log">View Auth Event Log →</Link>
         </div>
       </section>
     </div>

--- a/frontend/src/pages/SettingsAuthLog.jsx
+++ b/frontend/src/pages/SettingsAuthLog.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { MdFilterList } from "react-icons/md";
 import { getAuthLog } from "../api/client";
-import "./Settings.css";
-import "./AdminPanel.css";
+import "../components/Log.css";
 
 const ACTION_OPTIONS = [
   { value: "", label: "All actions" },
@@ -13,130 +14,179 @@ const ACTION_OPTIONS = [
   { value: "user_created", label: "User created" },
 ];
 
-function formatTimestamp(ts) {
-  return new Date(ts).toLocaleString();
-}
+const PAGE_SIZE = 20;
 
 function actionLabel(action) {
   const match = ACTION_OPTIONS.find((o) => o.value === action);
   return match ? match.label : action;
 }
 
-export default function SettingsAuthLog() {
-  const [username, setUsername] = useState("");
-  const [action, setAction] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
-  const [filters, setFilters] = useState({});
+function formatTimestamp(ts) {
+  return new Date(ts).toLocaleString();
+}
 
-  const { data: entries = [], isLoading, error } = useQuery({
+export default function SettingsAuthLog() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [page, setPage] = useState(0);
+
+  const filters = (() => {
+    const f = {};
+    const username = searchParams.get("username");
+    const action = searchParams.get("action");
+    const start_date = searchParams.get("start_date");
+    const end_date = searchParams.get("end_date");
+
+    if (username) f.username = username;
+    if (action) f.action = action;
+    if (start_date && /^\d{4}-\d{2}-\d{2}$/.test(start_date)) f.start_date = start_date;
+    if (end_date && /^\d{4}-\d{2}-\d{2}$/.test(end_date)) f.end_date = end_date;
+
+    return f;
+  })();
+
+  const { data: entries = [], isLoading, isError, error } = useQuery({
     queryKey: ["auth-log", filters],
     queryFn: () => getAuthLog(filters),
   });
 
-  const handleFilter = (e) => {
-    e.preventDefault();
-    setFilters({
-      ...(username ? { username } : {}),
-      ...(action ? { action } : {}),
-      ...(startDate ? { start_date: startDate } : {}),
-      ...(endDate ? { end_date: endDate } : {}),
+  const handleFilterChange = useCallback((key, value) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      return next;
     });
-  };
+    setPage(0);
+  }, [setSearchParams]);
 
-  const handleClear = () => {
-    setUsername("");
-    setAction("");
-    setStartDate("");
-    setEndDate("");
-    setFilters({});
+  const handleClearFilters = () => {
+    setSearchParams({});
+    setPage(0);
   };
 
   return (
-    <div className="settings-page">
-      <section className="settings-section">
-        <div className="section-row">
-          <h3>Auth Event Log</h3>
-        </div>
-        <hr />
-        <form onSubmit={handleFilter} style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem", alignItems: "flex-end" }}>
-          <div className="setting-group" style={{ flex: "1 1 160px" }}>
-            <label>Username</label>
+    <div className="log">
+      <div className="page-header">
+        <h2>Auth Event Log</h2>
+        <button
+          className="btn-secondary"
+          onClick={() => setFiltersExpanded(!filtersExpanded)}
+          title={filtersExpanded ? "Hide filters" : "Show filters"}
+        >
+          <MdFilterList className="action-icon" />
+          <span className="action-text">{filtersExpanded ? "Hide filters" : "Show filters"}</span>
+        </button>
+      </div>
+
+      {filtersExpanded && (
+        <div className="log-filters">
+          <div className="filter-group">
+            <label htmlFor="filter-auth-user">Filter by username</label>
             <input
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              id="filter-auth-user"
+              type="search"
+              autoComplete="off"
+              value={searchParams.get("username") || ""}
+              onChange={(e) => handleFilterChange("username", e.target.value)}
               placeholder="Filter by username"
             />
           </div>
-          <div className="setting-group" style={{ flex: "1 1 180px" }}>
-            <label>Action</label>
-            <select value={action} onChange={(e) => setAction(e.target.value)}>
+
+          <div className="filter-group">
+            <label htmlFor="filter-action">Filter by action</label>
+            <select
+              id="filter-action"
+              value={searchParams.get("action") || ""}
+              onChange={(e) => handleFilterChange("action", e.target.value)}
+            >
               {ACTION_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
               ))}
             </select>
           </div>
-          <div className="setting-group" style={{ flex: "1 1 140px" }}>
-            <label>Start date</label>
+
+          <div className="filter-group">
+            <label htmlFor="filter-start-date">Start date</label>
             <input
+              id="filter-start-date"
               type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+              value={searchParams.get("start_date") || ""}
+              onChange={(e) => handleFilterChange("start_date", e.target.value)}
             />
           </div>
-          <div className="setting-group" style={{ flex: "1 1 140px" }}>
-            <label>End date</label>
+
+          <div className="filter-group">
+            <label htmlFor="filter-end-date">End date</label>
             <input
+              id="filter-end-date"
               type="date"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+              value={searchParams.get("end_date") || ""}
+              onChange={(e) => handleFilterChange("end_date", e.target.value)}
             />
           </div>
-          <div style={{ display: "flex", gap: "0.5rem" }}>
-            <button type="submit" className="btn-primary">Filter</button>
-            <button type="button" className="btn-secondary" onClick={handleClear}>Clear</button>
-          </div>
-        </form>
 
-        {isLoading && <div className="loading">Loading auth log...</div>}
-        {error && <div className="error-message">{error.message}</div>}
+          <button className="btn-secondary" onClick={handleClearFilters}>
+            Clear filters
+          </button>
+        </div>
+      )}
 
-        {!isLoading && !error && (
-          <div style={{ overflowX: "auto" }}>
-            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}>
+      {isError && <div className="error-state">{error.message}</div>}
+
+      <div className="log-entries">
+        {isLoading ? (
+          <div className="loading">Loading auth log…</div>
+        ) : isError ? null : entries.length === 0 ? (
+          <div className="empty-state">No auth events found.</div>
+        ) : (
+          <>
+            <table className="log-table">
               <thead>
-                <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left" }}>
-                  <th style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted, var(--text))" }}>Timestamp</th>
-                  <th style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted, var(--text))" }}>Username</th>
-                  <th style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted, var(--text))" }}>Action</th>
-                  <th style={{ padding: "0.5rem 0.75rem", color: "var(--text-muted, var(--text))" }}>Changed By</th>
+                <tr>
+                  <th>Timestamp</th>
+                  <th>Username</th>
+                  <th>Action</th>
+                  <th>Changed By</th>
                 </tr>
               </thead>
               <tbody>
-                {entries.length === 0 ? (
-                  <tr>
-                    <td colSpan={4} style={{ padding: "1rem 0.75rem", color: "var(--text-muted, var(--text))", textAlign: "center" }}>
-                      No auth events found.
-                    </td>
+                {entries.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{formatTimestamp(entry.timestamp)}</td>
+                    <td>{entry.username}</td>
+                    <td>{actionLabel(entry.action)}</td>
+                    <td>{entry.changed_by ?? "—"}</td>
                   </tr>
-                ) : (
-                  entries.map((entry) => (
-                    <tr key={entry.id} style={{ borderBottom: "1px solid var(--border)" }}>
-                      <td style={{ padding: "0.5rem 0.75rem", whiteSpace: "nowrap" }}>{formatTimestamp(entry.timestamp)}</td>
-                      <td style={{ padding: "0.5rem 0.75rem" }}>{entry.username}</td>
-                      <td style={{ padding: "0.5rem 0.75rem" }}>{actionLabel(entry.action)}</td>
-                      <td style={{ padding: "0.5rem 0.75rem", color: entry.changed_by ? "inherit" : "var(--text-muted, var(--text))" }}>
-                        {entry.changed_by ?? "—"}
-                      </td>
-                    </tr>
-                  ))
-                )}
+                ))}
               </tbody>
             </table>
-          </div>
+
+            <div className="log-pagination">
+              <button
+                className="btn-secondary"
+                onClick={() => setPage(page - 1)}
+                disabled={page === 0}
+              >
+                ← Previous
+              </button>
+              <span className="page-info">
+                Page {page + 1} of {Math.ceil(entries.length / PAGE_SIZE)}
+              </span>
+              <button
+                className="btn-secondary"
+                onClick={() => setPage(page + 1)}
+                disabled={(page + 1) * PAGE_SIZE >= entries.length}
+              >
+                Next →
+              </button>
+            </div>
+          </>
         )}
-      </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refactor `SettingsAuthLog.jsx` to match main Log page visual language: `log-table` CSS class, collapsible `log-filters` panel with `MdFilterList` toggle, `log-pagination` controls at 20 rows/page
- Migrate filter state from local React state to URL search params (bookmarkable, survives back-nav)
- Add `page-header` with `<h2>Auth Event Log</h2>` matching Log page structure; import `Log.css`, drop inline styles
- Add `<h2>Auth</h2>` page heading to `SettingsAuth.jsx`; reorder sections (Authentication first, Auth Event Log link second); remove duplicate Auth Event Log section from #295
- Suppress browser credential autocomplete on username filter: `type="search"`, `autoComplete="off"`, non-heuristic id

## Issue

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)