### PR TITLE
fix: pin fastapi <0.137.0 to avoid 500 w/ starlette-prometheus

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.111.0
+fastapi>=0.111.0,<0.137.0  # 0.137+ introduces _IncludedRouter, breaks starlette-prometheus (unmaintained, assumes route.path on every matched route)
 uvicorn[standard]>=0.29.0
 sqlalchemy[asyncio]>=2.0.0
 asyncpg>=0.29.0


### PR DESCRIPTION
## Summary
- Fixes #303 — v2.0.0 crash: every request returned 500 after fastapi picked up an unpinned patch release.
- Root cause: `backend/requirements.txt` had `fastapi>=0.111.0` (no upper bound). fastapi 0.137.0 introduced an internal `_IncludedRouter` wrapper used by `include_router()`, which lacks a `.path` attribute. `starlette-prometheus`'s `PrometheusMiddleware.get_path_template` assumes every matched top-level route has `.path`, so it throws `AttributeError` on the first request that matches a router-mounted route — which is effectively all of them.
- The 2.0.0 rebuild pulled fastapi 0.137+ transitively since nothing pinned an upper bound; app code didn't change.
- Fix: pin `fastapi>=0.111.0,<0.137.0`.

## Test plan
- [x] Reproduced the exact `AttributeError: '_IncludedRouter' object has no attribute 'path'` traceback in an isolated venv with fastapi 0.137.0 + starlette-prometheus + a router-mounted route (matches issue traceback line for line).
- [x] Confirmed request returns 500 on fastapi 0.137.0, 200 after downgrading to fastapi<0.137.0 with the same code.
- [ ] Rebuild Docker image and confirm `/status/db-status` responds 200 in deployed environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)